### PR TITLE
Update RefJreEmulation.md

### DIFF
--- a/src/main/markdown/doc/latest/RefJreEmulation.md
+++ b/src/main/markdown/doc/latest/RefJreEmulation.md
@@ -1,4 +1,4 @@
-Jre Emulation
+JRE Emulation
 ===
 
 GWT includes a library that emulates a subset of the Java runtime library. 


### PR DESCRIPTION
Fully capitalized Jre in the title line so that it now reads JRE Emulation. JRE is an acronym and by convention acronyms are fully capitalized.