### PR TITLE
Remove deprecated  function call

### DIFF
--- a/src/main/markdown/doc/latest/tutorial/codeclient.md
+++ b/src/main/markdown/doc/latest/tutorial/codeclient.md
@@ -401,9 +401,10 @@ The final piece of functionality you need to implement is the timestamp. You use
               }
 
               // Display timestamp showing last refresh.
-              lastUpdatedLabel.setText("Last update : "
-                + DateTimeFormat.getMediumDateTimeFormat().format(new Date()));
-
+              DateTimeFormat dateFormat = DateTimeFormat.getFormat(
+                DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM);
+              lastUpdatedLabel.setText("Last update : " 
+                + dateFormat.format(new Date()));
             }
     
     *  Eclipse flags DateTimeFormat and Date.


### PR DESCRIPTION
DateTimeFormat.getMediumDateTimeFormat() is now deprecated.

It is recommended that DateTimeFormat.PredefinedFormat.DATE_TIME_MEDIUM is used in its place.