### PR TITLE
Update JSON.md

### DIFF
--- a/src/main/markdown/doc/latest/tutorial/JSON.md
+++ b/src/main/markdown/doc/latest/tutorial/JSON.md
@@ -427,7 +427,6 @@ The RequestCallback interface is analogous to the AsyncCallback interface in GWT
     *  In the refreshWatchList method, replace the TODO comments with the following code  .
 
     ```
-    
     // Send request to server and catch any errors.
         RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
     


### PR DESCRIPTION
Visual miss place on the code section (<enter>) did not show the first two lines

Chrome Version 41.0.2272.89 (64-bit)