### PR TITLE
Fixed broken link on webAppCreator

### DIFF
--- a/src/main/markdown/gettingstarted.md
+++ b/src/main/markdown/gettingstarted.md
@@ -56,7 +56,7 @@ run and use the SDK are located in the extracted directory.
 
 ## Create your first web application<a id="create"></a>
 
-GWT ships with a command line utility called [webAppCreator](doc/latest/RefCommandLineTools.html#webAppCreator) that automatically generates all the files you'll need in order to start a GWT project.  It also generates [Eclipse](http://www.eclipse.org/) project files and launch config files for easy debugging in GWT's development mode.
+GWT ships with a command line utility called [webAppCreator](http://www.gwtproject.org/doc/latest/RefCommandLineTools.html#webAppCreator) that automatically generates all the files you'll need in order to start a GWT project.  It also generates [Eclipse](http://www.eclipse.org/) project files and launch config files for easy debugging in GWT's development mode.
 
 You can create a new demo application in a new MyWebApp directory by running `webAppCreator`:
 


### PR DESCRIPTION
Looks like the link to documentation on the `webAppCreator` class [on the Getting Started page](http://www.gwtproject.org/gettingstarted.html) is not entirely correct and the raw markdown is being displayed instead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/87)
<!-- Reviewable:end -->
