### PR TITLE
Some css fixes in lists.

### DIFF
--- a/src/main/site/assets/less/layout.less
+++ b/src/main/site/assets/less/layout.less
@@ -168,7 +168,6 @@ textarea {
 
 p {
   line-height: 1.4em;
-  margin-bottom: 0.8em;
 }
 
 strong {
@@ -177,6 +176,7 @@ strong {
 
 em {
   font-style: italic;
+  font-size: 90%;
 }
 
 hr {
@@ -220,6 +220,7 @@ ul {
 
   & > li {
     list-style-type: none;
+    margin-top: 0.8em;
 
     &::before {
       content: "";
@@ -238,6 +239,10 @@ ul {
     ul li::before {
       color: #000;
     }
+
+    & > p:first-child {
+     display: inline;
+    }
   }
 }
 
@@ -246,13 +251,20 @@ ol {
 
   & > li {
     list-style-type: none;
+    margin-top: 0.8em;
 
     &::before{
       content: counter(item) " | ";
       counter-increment: item;
       color: @c-primary-dark;
-
       margin-left: -20px;
+      font-family: monospace;
+      font-weight: bold;
+      font-size: 120%;
+    }
+
+    & > p:first-child {
+     display: inline;
     }
   }
 

--- a/src/main/site/assets/less/layout.less
+++ b/src/main/site/assets/less/layout.less
@@ -211,8 +211,13 @@ ul,
 ol {
   list-style-position: outside;
 
+  margin-top: 0.8em;
   margin-left: 1.3em;
   padding-left: 0;
+
+  & > li > p:first-child {
+   display: inline;
+  }
 }
 
 ul {
@@ -220,7 +225,6 @@ ul {
 
   & > li {
     list-style-type: none;
-    margin-top: 0.8em;
 
     &::before {
       content: "";
@@ -239,10 +243,6 @@ ul {
     ul li::before {
       color: #000;
     }
-
-    & > p:first-child {
-     display: inline;
-    }
   }
 }
 
@@ -251,7 +251,6 @@ ol {
 
   & > li {
     list-style-type: none;
-    margin-top: 0.8em;
 
     &::before{
       content: counter(item) " | ";
@@ -261,10 +260,6 @@ ol {
       font-family: monospace;
       font-weight: bold;
       font-size: 120%;
-    }
-
-    & > p:first-child {
-     display: inline;
     }
   }
 


### PR DESCRIPTION
- Sometimes pegdown encloses first description in &lt;p>, setting display
  inline so as there is no line breaks.
- Numbered lines font should be monospaced so as the pipe separator
  is always in the same position.
- Space between &lt;li> was very small if last element is not a &lt;p>.
- Reduce font of italic to diferentiate.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/92)
<!-- Reviewable:end -->
