### PR TITLE
Don not break code lines, use scrolling instead.

### DIFF
--- a/src/main/site/assets/less/layout.less
+++ b/src/main/site/assets/less/layout.less
@@ -30,10 +30,6 @@ body {
   padding: 0;
 }
 
-.holder {
-  display: table;
-}
-
 .container {
   margin: 0;
   padding: 0 50px 0 50px;
@@ -270,8 +266,9 @@ ol {
 
 code {
   background-color: #fff;
-
   display: inline;
+  font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
+  font-size: 85% !important;
 }
 
 pre > code {

--- a/src/main/site/assets/less/normalize.less
+++ b/src/main/site/assets/less/normalize.less
@@ -225,16 +225,6 @@ samp {
 }
 
 /**
- * Improve readability of pre-formatted text in all browsers.
- */
-
-pre {
-    white-space: pre;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-}
-
-/**
  * Address CSS quotes not supported in IE 6/7.
  */
 


### PR DESCRIPTION
Breaking code makes code look unformated, it is better
to maintain the original author's format and let the user
scroll to vew full code.
Also better selection of fonts because in android code
was not shown with monospaced fonts

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/103)
<!-- Reviewable:end -->
