### PR TITLE
Replace deprecated PropertiesFormat with new PropertyCatalogFactory in UiBinder I18N example

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideUiBinderI18n.md
+++ b/src/main/markdown/doc/latest/DevGuideUiBinderI18n.md
@@ -41,7 +41,7 @@ Here's how to turn the feature on.
 
 ```
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-    ui:generateFormat='com.google.gwt.i18n.rebind.format.PropertiesFormat'
+    ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
     ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
     ui:generateLocales="default">
   <div><ui:msg description="Greeting">Hello, world.</ui:msg></div>


### PR DESCRIPTION
gwtproject/gwt#9154

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/106)
<!-- Reviewable:end -->
