### PR TITLE
Removed codetalks.org as source of information about ARIA as it does not contain it

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideA11y.md
+++ b/src/main/markdown/doc/latest/DevGuideA11y.md
@@ -38,9 +38,7 @@ easily imagine how this causes problems.
 
 ### ARIA
 
-[ARIA](http://www.w3.org/WAI/intro/aria) is a W3C specification for making rich Internet applications accessible via a
-standard set of DOM properties. It is still new but there exist helpful resources on the web. More information can be
-found at [Google accessibility site](http://www.google.com/accessibility/) and [Chrome accessibility extensions page](http://code.google.com/p/google-axs-chrome/).
+[ARIA](http://www.w3.org/WAI/intro/aria) is a W3C specification for making rich Internet applications accessible via a standard set of DOM properties. It is still new but there exist helpful resources on the web. More information can be found at [Google accessibility site](http://www.google.com/accessibility/) and [Chrome accessibility extensions page](http://code.google.com/p/google-axs-chrome/).
 
 Adding accessibility support to GWT widgets involves adding the relevant properties to DOM elements that can be used by browsers to raise events during user interaction. Screen readers can react to these events to represent the function of GWT widgets. The DOM properties specified by ARIA are classified into Roles with their Properties and States.
 

--- a/src/main/markdown/doc/latest/DevGuideA11y.md
+++ b/src/main/markdown/doc/latest/DevGuideA11y.md
@@ -38,7 +38,9 @@ easily imagine how this causes problems.
 
 ### ARIA
 
-[ARIA](http://www.w3.org/WAI/intro/aria) is a W3C specification for making rich Internet applications accessible via a standard set of DOM properties. It is still new but there exist helpful resources on the web. More information can be found at [Google accessibility site](http://www.google.com/accessibility/), [Chrome accessibility extensions page](http://code.google.com/p/google-axs-chrome/), and codetalks.org.
+[ARIA](http://www.w3.org/WAI/intro/aria) is a W3C specification for making rich Internet applications accessible via a
+standard set of DOM properties. It is still new but there exist helpful resources on the web. More information can be
+found at [Google accessibility site](http://www.google.com/accessibility/) and [Chrome accessibility extensions page](http://code.google.com/p/google-axs-chrome/).
 
 Adding accessibility support to GWT widgets involves adding the relevant properties to DOM elements that can be used by browsers to raise events during user interaction. Screen readers can react to these events to represent the function of GWT widgets. The DOM properties specified by ARIA are classified into Roles with their Properties and States.
 


### PR DESCRIPTION
codetalks.org does not contain any information about ARIA and it is not worth mentioning in article about a11y. This is the same pull request as #107 but is created from separate branch (not master).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/108)
<!-- Reviewable:end -->
