### PR TITLE
Revert "Hide the main div while loading"

### DIFF
--- a/src/main/resources/main.tpl
+++ b/src/main/resources/main.tpl
@@ -75,7 +75,7 @@
             </div>
         </nav>
 
-        <div class="holder" style="display:none">
+        <div class="holder">
             <aside id="submenu">
                 <nav>
                     $toc


### PR DESCRIPTION
This reverts commit 25233ca5df1d35fbf579688fbdc164d1d0dc4131.

That commit caused [issue #79](https://github.com/gwtproject/gwt-site/issues/79). Maybe there is a way to achieve the desired behaviour without disrupting the workflow of (potential) contributors to the documentation?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/111)
<!-- Reviewable:end -->
