### PR TITLE
Fix broken links

### DIFF
--- a/src/main/markdown/articles/using_gwt_with_hibernate.md
+++ b/src/main/markdown/articles/using_gwt_with_hibernate.md
@@ -681,7 +681,7 @@ Gilead also provides a dedicated adapter for Hibernate and GWT to make their int
 In the simplest case, integration between GWT and Hibernate can be realized by following these steps:
 
 1.  Make your persistent classes inherit the `LightEntity` class (class used for stateless mode integration in the Gilead library).
-2.  Making your remote RPC services extend `[PersistentRemoteService](http://gilead.svn.sourceforge.net/viewvc/gilead/gilead/branches/1.2/adapter4gwt/src/net/sf/gilead/gwt/PersistentRemoteService.java?revision=896&view=markup)` instead of `[RemoteServiceServlet](/javadoc/latest/com/google/gwt/user/server/rpc/RemoteServiceServlet.html)`.
+2.  Making your remote RPC services extend [`PersistentRemoteService`](http://gilead.svn.sourceforge.net/viewvc/gilead/gilead/branches/1.2/adapter4gwt/src/net/sf/gilead/gwt/PersistentRemoteService.java?revision=896&view=markup) instead of [`RemoteServiceServlet`](/javadoc/latest/com/google/gwt/user/server/rpc/RemoteServiceServlet.html).
 3.  Configuring your beanManager for your GWT RPC service as shown in the code snippet below (see [Gilead documentation](http://noon.gilead.free.fr/gilead/index.php?page=documentation) for more on configuring bean managers):
 
 ```

--- a/src/main/markdown/doc/latest/DevGuideClientBundle.md
+++ b/src/main/markdown/doc/latest/DevGuideClientBundle.md
@@ -92,17 +92,17 @@ This will work equally well with all resource types, which can allow you to prov
 
 ### Pluggable Resource Generation<a id="Pluggable_Resource_Generation"></a>
 
-Each subtype of `[ResourcePrototype](/javadoc/latest/index.html?com/google/gwt/resources/client/ResourcePrototype.html)` must define a `[@ResourceGeneratorType](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceGeneratorType.html)` annotation whose value is a concrete Java class that extends `[ResourceGenerator](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceGenerator.html)`.  The instance of the `ResourceGenerator` is responsible for accumulation (or bundling) of incoming resource data as well as a small degree of code generation to assemble the concrete implementation of the `ClientBundle` class.  Implementors of `ResourceGenerator` subclasses can expect that only one `ResourceGenerator` will be created for a given type of resource within a `ClientBundle` interface.
+Each subtype of [`ResourcePrototype`](/javadoc/latest/index.html?com/google/gwt/resources/client/ResourcePrototype.html) must define a [`@ResourceGeneratorType`](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceGeneratorType.html) annotation whose value is a concrete Java class that extends [`ResourceGenerator`](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceGenerator.html).  The instance of the `ResourceGenerator` is responsible for accumulation (or bundling) of incoming resource data as well as a small degree of code generation to assemble the concrete implementation of the `ClientBundle` class.  Implementors of `ResourceGenerator` subclasses can expect that only one `ResourceGenerator` will be created for a given type of resource within a `ClientBundle` interface.
 
 The methods on a `ResourceGenerator` are called in the following order
 
-1.  `init` to provide the `ResourceGenerator` with a `[ResourceContext](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceContext.html)`
+1.  `init` to provide the `ResourceGenerator` with a [`ResourceContext`](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceContext.html)
 2.  `prepare` is called for each `JMethod` the `ResourceGenerator` is expected to handle
 3.  `createFields` allows the `ResourceGenerator` to add code at the class level
 4.  `createAssignment` is called for each `JMethod`.  The generated code should be suitable for use as the right-hand side of an assignment expression.
 5.  `finish` is called after all assignments should have been written.
 
-`ResourceGenerators` are expected to make use of the `[ResourceGeneratorUtil](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceGeneratorUtil.html)` class.
+`ResourceGenerators` are expected to make use of the [`ResourceGeneratorUtil`](/javadoc/latest/index.html?com/google/gwt/resources/ext/ResourceGeneratorUtil.html) class.
 
 ### Levers and knobs<a id="Levers_and_knobs"></a>
 

--- a/src/main/markdown/doc/latest/DevGuideServerCommunication.md
+++ b/src/main/markdown/doc/latest/DevGuideServerCommunication.md
@@ -396,8 +396,8 @@ For example, the custom field serializer for `java.util.HashMap` is
 `com.google.gwt.user.client.rpc.core.java.util.HashMap_CustomFieldSerializer`.
 
 Custom field serializers should extend the 
-`[
-CustomFieldSerializer<T>](/javadoc/latest/com/google/gwt/user/client/rpc/CustomFieldSerializer.html)` class, with the class that is being
+[`
+CustomFieldSerializer<T>`](/javadoc/latest/com/google/gwt/user/client/rpc/CustomFieldSerializer.html) class, with the class that is being
 serialized as the type parameter. For example:
 
 ```
@@ -437,8 +437,8 @@ and the server type-checked version is
 `test.com.google.gwt.user.server.rpc.TypeCheckedGenericClass_ServerCustomFieldSerializer`.
 
 Server custom field serializers should extend the 
-`[
-ServerCustomFieldSerializer<T>](/javadoc/latest/com/google/gwt/user/server/rpc/ServerCustomFieldSerializer.html)` class, with the class that is being
+[`
+ServerCustomFieldSerializer<T>`](/javadoc/latest/com/google/gwt/user/server/rpc/ServerCustomFieldSerializer.html) class, with the class that is being
 serialized as the type parameter. For example:
 
 ```

--- a/src/main/markdown/doc/latest/DevGuideUiBinder.md
+++ b/src/main/markdown/doc/latest/DevGuideUiBinder.md
@@ -339,7 +339,7 @@ elements. That is, `<g:Button>`, not `<button>`.
 ## Using a widget that requires constructor args<a id="Using_a_widget"></a>
 
 Every widget that is declared in a template is created by a call
-to `[GWT.create](/javadoc/latest/com/google/gwt/core/client/GWT.html#create%28java.lang.Class%29)()`. In
+to [`GWT.create`](/javadoc/latest/com/google/gwt/core/client/GWT.html#create%28java.lang.Class%29)(). In
 most cases this means that they must be default instantiable; that is,
 they must provide a zero-argument constructor. However, there are a few ways to
 get around that. In addition to the `@UiFactory` and
@@ -647,10 +647,10 @@ res.style().ensureInjected();
 The "`with`" element declares a field holding a resource
 object whose methods can be called to fill in attribute values.  In
 this case it will be instantiated via a call
-to `[GWT.create](/javadoc/latest/com/google/gwt/core/client/GWT.html#create%28java.lang.Class%29)(Resources.class)`. (Read on to see how pass an instance in instead
+to [`GWT.create`](/javadoc/latest/com/google/gwt/core/client/GWT.html#create%28java.lang.Class%29)(Resources.class). (Read on to see how pass an instance in instead
 of having it created for you.)
 
-Note that there is no requirement that a `ui:with` resource implement the [ClientBundle](/javadoc/latest/com/google/gwt/resources/client/ClientBundle.html) interface; this is just an example.
+Note that there is no requirement that a `ui:with` resource implement the [`ClientBundle`](/javadoc/latest/com/google/gwt/resources/client/ClientBundle.html) interface; this is just an example.
 
 If you need more flexibility with a resource, you can set
 parameters on it with a `<ui:attributes>` element. Any

--- a/src/main/markdown/doc/latest/DevGuideUiBinderI18n.md
+++ b/src/main/markdown/doc/latest/DevGuideUiBinderI18n.md
@@ -23,7 +23,7 @@ As in the main <a href="DevGuideUiBinder.html">UiBinder
 page</a>, the rest of this page explains how to make your UI templates
 localizable through a series of typical use cases.
 
-**Note** You will see a lot of parallels to working with the [Messages](DevGuideI18nMessages.html) system, and with good reason: UiBinder's I18n features are implemented by generating a hidden `[com.google.gwt.i18n.client.Messages](/javadoc/latest/com/google/gwt/i18n/client/Messages.html)` interface for each template. Except for plural forms, anything you can do via Messages you should also be able to do in a template.
+**Note** You will see a lot of parallels to working with the [Messages](DevGuideI18nMessages.html) system, and with good reason: UiBinder's I18n features are implemented by generating a hidden [`com.google.gwt.i18n.client.Messages`](/javadoc/latest/com/google/gwt/i18n/client/Messages.html) interface for each template. Except for plural forms, anything you can do via Messages you should also be able to do in a template.
  
 ## Bonjour, Tout Le Monde<a id="Bonjour"></a>
 
@@ -147,7 +147,7 @@ default values.
 <dl>
   <dt>`ui:baseMessagesInterface`
   <dd>Sets the base interface to use for generated messages.  The value must
-  be the fully-qualified class name of an interface that extends `[Messages](/javadoc/latest/com/google/gwt/i18n/client/Messages.html)`.
+  be the fully-qualified class name of an interface that extends [`Messages`](/javadoc/latest/com/google/gwt/i18n/client/Messages.html).
   You can then put whatever annotations you want there, making it easy to have
   company or project-wide settings that can be changed in just one place.  You
   can still use the other attributes to override defaults inherited from that


### PR DESCRIPTION
a couple of links were showing as `[example](example.org)` instead of [`example`](example.org)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/112)
<!-- Reviewable:end -->
