### PR TITLE
Tiny typo in the i18n docs

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideUiBinderI18n.md
+++ b/src/main/markdown/doc/latest/DevGuideUiBinderI18n.md
@@ -87,7 +87,7 @@ about the default locale and fallback properties
 in [Locales in GWT](DevGuideI18nLocale.html).)
 </dl>
 
-When you compile your application, pass the -extras argument to 
+When you compile your application, pass the `-extra` argument to 
 the gwt compiler to tell it to generate its "extra" auxiliary files.
 A properties file will be generated for each template, containing
 an entry for each message tagged for localization, something like:


### PR DESCRIPTION
Looks like there's a typo for the argument to pass into the compiler for i18n. This is just a small tweak.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/124)
<!-- Reviewable:end -->
