### PR TITLE
Update community.md

### DIFF
--- a/src/main/markdown/community.md
+++ b/src/main/markdown/community.md
@@ -14,6 +14,9 @@ We've established a set of discussion groups/mailing lists to help you find answ
 *   **GWT Contributors** - If interested in contributing to the [GWT open source project](makinggwtbetter.html) this is your group. For more general questions not concerned with source code contribution, please use the general discussion forum.
     *   Go to the group: [google-web-toolkit-contributors](http://groups.google.com/group/google-web-toolkit-contributors)
     *   Subscribe via email: [google-web-toolkit-contributors-subscribe@googlegroups.com](mailto:google-web-toolkit-contributors-subscribe@googlegroups.com)
+*   **GWT Steering** - This is the place where the GWT Steering Committee talks in the open about the future of the project (roadmap, communication, etc.) and bureaucratic stuff. Your feedback is (more than) welcome, so do not hesitate to send it to the GWT Contributors group. 
+    *   Go to the group: [gwt-steering](http://groups.google.com/group/gwt-steering)
+    *   Subscribe via email: [google-web-toolkit-contributors-subscribe@googlegroups.com](mailto:gwt-steering-subscribe@googlegroups.com)
 *   **Speed Tracer** - If you are interested in hearing about new features, or in contributing to Speed Tracer.
     *   Go to the group: [speedtracer](https://groups.google.com/group/speedtracer)
     *   Visit the [codesite project](http://code.google.com/p/speedtracer).

--- a/src/main/markdown/community.md
+++ b/src/main/markdown/community.md
@@ -16,7 +16,7 @@ We've established a set of discussion groups/mailing lists to help you find answ
     *   Subscribe via email: [google-web-toolkit-contributors-subscribe@googlegroups.com](mailto:google-web-toolkit-contributors-subscribe@googlegroups.com)
 *   **GWT Steering** - This is the place where the GWT Steering Committee talks in the open about the future of the project (roadmap, communication, etc.) and bureaucratic stuff. Your feedback is (more than) welcome, so do not hesitate to send it to the GWT Contributors group. 
     *   Go to the group: [gwt-steering](http://groups.google.com/group/gwt-steering)
-    *   Subscribe via email: [google-web-toolkit-contributors-subscribe@googlegroups.com](mailto:gwt-steering-subscribe@googlegroups.com)
+    *   Subscribe via email: [gwt-steering-subscribe@googlegroups.com](mailto:gwt-steering-subscribe@googlegroups.com)
 *   **Speed Tracer** - If you are interested in hearing about new features, or in contributing to Speed Tracer.
     *   Go to the group: [speedtracer](https://groups.google.com/group/speedtracer)
     *   Visit the [codesite project](http://code.google.com/p/speedtracer).


### PR DESCRIPTION
The GWT Steering Google group is not listed anywhere on the site that I can see.  It seems natural for it to be listed under resources.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/129)
<!-- Reviewable:end -->
