### PR TITLE
correct usage of paper-icon-item

### DIFF
--- a/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
@@ -49,19 +49,19 @@ In this chapter we'll build a modern looking UI for the **TodoList** application
 
             <g:HTMLPanel>
                 <paper-icon-item ui:field="menuClearAll">
-                    <iron-icon icon="delete"/>
+                    <iron-icon icon="delete" item-icon/>
                     <div>Clear All</div>
                 </paper-icon-item>
                 <paper-icon-item ui:field="menuClearDone">
-                    <iron-icon icon="clear"/>
+                    <iron-icon icon="clear" item-icon/>
                     <div>Clear Done</div>
                 </paper-icon-item>
                 <paper-icon-item ui:field="menuSettings">
-                    <iron-icon icon="settings"/>
+                    <iron-icon icon="settings" item-icon/>
                     <div>Settings</div>
                 </paper-icon-item>
                 <paper-icon-item ui:field="menuAbout">
-                    <iron-icon icon="help"/>
+                    <iron-icon icon="help" item-icon/>
                     <div>About</div>
                 </paper-icon-item>
             </g:HTMLPanel>

--- a/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
@@ -168,22 +168,22 @@ In this chapter we'll build a modern looking UI for the **TodoList** application
                     }
                 </style>
                 <paper-icon-item ui:field="menuClearAll">
-                    <iron-icon icon="delete"/>
+                    <iron-icon icon="delete" item-icon/>
                     <div>Clear All</div>
                     <paper-ripple/>
                 </paper-icon-item>
                 <paper-icon-item ui:field="menuClearDone">
-                    <iron-icon icon="clear"/>
+                    <iron-icon icon="clear" item-icon/>
                     <div>Clear Done</div>
                     <paper-ripple/>
                 </paper-icon-item>
                 <paper-icon-item ui:field="menuSettings">
-                    <iron-icon icon="settings"/>
+                    <iron-icon icon="settings" item-icon/>
                     <div>Settings</div>
                     <paper-ripple/>
                 </paper-icon-item>
                 <paper-icon-item ui:field="menuAbout">
-                    <iron-icon icon="help"/>
+                    <iron-icon icon="help" item-icon/>
                     <div>About</div>
                     <paper-ripple/>
                 </paper-icon-item>
@@ -246,22 +246,22 @@ In this chapter we'll build a modern looking UI for the **TodoList** application
                         <paper-header-panel mode="seamed">
                             <paper-toolbar/>
                             <paper-icon-item ui:field="menuClearAll">
-                                <iron-icon icon="delete"/>
+                                <iron-icon icon="delete" item-icon/>
                                 <div>Clear All</div>
                                 <paper-ripple/>
                             </paper-icon-item>
                             <paper-icon-item ui:field="menuClearDone">
-                                <iron-icon icon="clear"/>
+                                <iron-icon icon="clear" item-icon/>
                                 <div>Clear Done</div>
                                 <paper-ripple/>
                             </paper-icon-item>
                             <paper-icon-item ui:field="menuSettings">
-                                <iron-icon icon="settings"/>
+                                <iron-icon icon="settings" item-icon/>
                                 <div>Settings</div>
                                 <paper-ripple/>
                             </paper-icon-item>
                             <paper-icon-item ui:field="menuAbout">
-                                <iron-icon icon="help"/>
+                                <iron-icon icon="help" item-icon/>
                                 <div>About</div>
                                 <paper-ripple/>
                             </paper-icon-item>
@@ -413,22 +413,22 @@ Finally your `Main.ui.xml` file should look like:
                     <paper-header-panel mode="seamed">
                         <paper-toolbar class="toolbar"/>
                         <paper-icon-item ui:field="menuClearAll">
-                            <iron-icon icon="delete"/>
+                            <iron-icon icon="delete" item-icon/>
                             <div>Clear All</div>
                             <paper-ripple/>
                         </paper-icon-item>
                         <paper-icon-item ui:field="menuClearDone">
-                            <iron-icon icon="clear"/>
+                            <iron-icon icon="clear" item-icon/>
                             <div>Clear Done</div>
                             <paper-ripple/>
                         </paper-icon-item>
                         <paper-icon-item ui:field="menuSettings">
-                            <iron-icon icon="settings"/>
+                            <iron-icon icon="settings" item-icon/>
                             <div>Settings</div>
                             <paper-ripple/>
                         </paper-icon-item>
                         <paper-icon-item ui:field="menuAbout">
-                            <iron-icon icon="help"/>
+                            <iron-icon icon="help" item-icon/>
                             <div>About</div>
                             <paper-ripple/>
                         </paper-icon-item>


### PR DESCRIPTION
by adding "item-icon" it specifies, that the icon is used inside the paper-item. that allows for example the expected correct side alignment of the icons, which still works if a description(for example "Clear All") is longer.

example of how it should look like: http://s18.postimg.org/wy5s2vot5/gwtpoly.png
 
check out the polymer elements side for reference:
https://github.com/PolymerElements/paper-item/blob/master/demo/index.html#L102
https://elements.polymer-project.org/elements/paper-item?view=demo:demo/index.html&active=paper-item


so this:

    <paper-icon-item role="listitem" class="x-scope paper-icon-item-0">
    <div class="content-icon layout horizontal center style-scope paper-icon-item" id="contentIcon">
      
    </div>
    <iron-icon class="x-scope iron-icon-0">...</iron-icon> 
    <div>Clear All</div> 
    <paper-ripple>
    <div id="background" class="style-scope paper-ripple" style="opacity: 0.009872;"></div>
    <div id="waves" class="style-scope paper-ripple"></div>
    </paper-ripple>
    </paper-icon-item>

becomes this:

    <paper-icon-item class="x-scope paper-icon-item-0" role="listitem">
    <div id="contentIcon" class="content-icon layout horizontal center style-scope paper-icon-item">
        <iron-icon class="x-scope iron-icon-0"></iron-icon> 
    </div>   
    <div>Clear All</div> 
    <paper-ripple>
    <div class="style-scope paper-ripple" id="background"></div>
    <div class="style-scope paper-ripple" id="waves"></div>
    </paper-ripple>
    </paper-icon-item>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/157)
<!-- Reviewable:end -->
