### PR TITLE
Update PaperCheckBox field name to match Java

### DIFF
--- a/src/main/markdown/doc/latest/polymer-tutorial/widgets-applogic.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/widgets-applogic.md
@@ -77,7 +77,7 @@ In this section, we'll learn how to add logic to our UI. We'll touch on very bas
                 </style>
                 <div class="vertical-section">
                   <h4>
-                    <p:PaperCheckbox ui:field="check"></p:PaperCheckbox>
+                    <p:PaperCheckbox ui:field="done"></p:PaperCheckbox>
                     <span ui:field="title" class='{style.title}'>Go to Google</span>
                   </h4>
                   <div ui:field="description" class='{style.description}'></div>


### PR DESCRIPTION
Current version has mismatch between the Java and XML files for naming the PaperCheckBox. Java field is named "done", XML names it "check". This causes compile error.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/159)
<!-- Reviewable:end -->
