### PR TITLE
Fix https issue link

### DIFF
--- a/src/main/markdown/articles/superdevmode.md
+++ b/src/main/markdown/articles/superdevmode.md
@@ -190,7 +190,7 @@ asks. Therefore, we recommend only running it on localhost or behind a firewall.
 by default.)
 
 * https is not supported. See
-[issue 7538](https://code.google.com/p/google-web-toolkit/issues/detail?id=7538)
+[issue 7535](https://github.com/gwtproject/gwt/issues/7535)
 for updates.
 
 * Although all modern browser have some support for sourcemaps, sourcemap-based debugging currently


### PR DESCRIPTION
Update issue link for https "is not supported" to point to github link and use github issue #.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/172)
<!-- Reviewable:end -->
