### PR TITLE
Fix extra indentation of code snippets in GSS Migration Guide

### DIFF
--- a/src/main/markdown/articles/gss_migration.md
+++ b/src/main/markdown/articles/gss_migration.md
@@ -80,12 +80,12 @@ MyCssResource css();
 turn off auto conversion:
 
 
-    ```
-    <set-configuration-property name="CssResource.conversionMode" value="off" />
-    ```
+```
+<set-configuration-property name="CssResource.conversionMode" value="off" />
+```
 
   7. Remove all .css
-  8. Live happily ever after in CSS3 land 
+  8. Live happily ever after in CSS3 land
 
 ## One step migration
 
@@ -98,9 +98,9 @@ turn off auto conversion:
   6. Turn off auto conversion for app:
 
 
-    ```
-    <set-configuration-property name="CssResource.conversionMode" value="off" />
-    ```
+```
+<set-configuration-property name="CssResource.conversionMode" value="off" />
+```
 
   7. Live happily ever after in CSS3 land
 


### PR DESCRIPTION
These two snippets are already surrounded with "```" and should not be
indented 4 spaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/175)
<!-- Reviewable:end -->
