### PR TITLE
Cleanup outdated information

### DIFF
--- a/src/main/markdown/community.md
+++ b/src/main/markdown/community.md
@@ -47,8 +47,6 @@ There are several ways to contribute back to the GWT community.
 
 To see how other developers used GWT to build real-world applications, be sure to checkout our [Developer Spotlight](developer_spotlight.html) section. Here developers from several third-party companies talk about specific features that they used to build their applications, what they like and would like to see from GWT, as well as tips and learnings from developing with GWT.
 
-If you'd like to see who else is using GWT, check out the [GWT Gallery](http://gwtgallery.appspot.com). You'll be able to find other applications and libraries built with GWT, comment on them, rate them, and search for them by tag or by name. You can also [submit your own entry](http://gwtgallery.appspot.com/submit) if you have a project that  you want to share.
-
-You can also find a wide variety of open source [ projects related to GWT](http://code.google.com/hosting/search?q=GWT&btn=Search+Projects) hosted on Google Code.
+You can also find a wide variety of open source [projects related to GWT](https://github.com/search?q=GWT) hosted on Github.
 
 Please note that the applications linked from this page are provided by third parties and are not endorsed by Google.

--- a/src/main/markdown/developer_spotlight.md
+++ b/src/main/markdown/developer_spotlight.md
@@ -122,8 +122,6 @@ Watch developers talk about their web applications and how they used GWT to buil
   </tr>
 </table>
 
-If you'd like to see who else is using GWT, check out the [GWT Gallery](http://gwtgallery.appspot.com). You'll be able to find other applications and libraries built with GWT, comment on them, rate them, and search for them by tag or by name. You can also [submit your own entry](http://gwtgallery.appspot.com/submit) if you have a project that you want to share.
-
-You can also find a wide variety of open source [projects related to GWT](http://code.google.com/hosting/search?q=GWT&btn=Search+Projects) hosted on Google Code.
+You can also find a wide variety of open source [projects related to GWT](https://github.com/search?q=GWT) hosted on Github.
 
 Please note that the applications linked from this page are provided by third-parties and are not endorsed by the GWT project or Google.

--- a/src/main/markdown/examples.md
+++ b/src/main/markdown/examples.md
@@ -75,8 +75,6 @@ If you're like us, the first thing you want to do is see examples of what you ca
 *   [Samples](#samples) are included in the SDK for you to play around with and build off of. A few are below. Some are from the [App Engine SDK](https://developers.google.com/appengine/) that use GWT for their front end.
 *   [Real world projects](#real-world-projects) let you see the real power of GWT, with complex applications that developers are building.
 
-If you'd like to see who else is using GWT, check out the [GWT Gallery](http://gwtgallery.appspot.com). You'll be able to find other applications and libraries built with GWT, comment on them, rate them, and search for them by tag or by name. You can also [submit your own entry](http://gwtgallery.appspot.com/submit) if you have a project that  you want to share.
-
 You can also find a wide variety of open source [projects related to GWT](https://github.com/search?q=GWT) hosted on Github.
 
 Please note that the applications linked from this page are provided by third-parties and are not endorsed by Google.

--- a/src/main/markdown/gettingstarted.md
+++ b/src/main/markdown/gettingstarted.md
@@ -100,14 +100,10 @@ This command starts GWT's development mode server, a local server used for devel
 
 Launch the local server in a browser by either 1) clicking "Launch Default Browser"
 or 2) clicking "Copy to Clipboard" (to copy its URL), then pasting into Firefox, Internet Explorer,
-Chrome, or Safari. Since this is your first time
-hitting the development mode server, it will prompt you to install the GWT
-Developer Plugin. Follow the instructions in the browser to install the plugin, which
-may require restarting the browser.
+Chrome, or Safari.
 
-Once the GWT Developer Plugin is installed in your browser, navigate to
-the URL again and the starter application will load in development mode, as follows:.
-  
+The starter application will load in Super Dev Mode as follows:
+
 <div class="screenshot"><a href="images/myapplication-browser.png"><img src="images/myapplication-browser.png" alt="Screenshot" width="35%"/></a></div>
 
 ## Make a few changes<a id="change"></a>

--- a/src/main/markdown/makinggwtbetter.md
+++ b/src/main/markdown/makinggwtbetter.md
@@ -589,6 +589,6 @@ If you wish to contribute to the GWT code used on the site (to improve navigatio
 
 Since our .gitignore files don't contain IDE or OS specific .gitignore entries you should setup your global .gitignore.
 
-[This](https://help.github.com/articles/ignoring-files) is how you setup a global .gitingore.
+[This](https://help.github.com/articles/ignoring-files) is how you setup a global .gitignore.
 
 [Here](https://github.com/github/gitignore/tree/master/Global) you find a list of IDE specific global .gitignore files.


### PR DESCRIPTION
- Remove link to "GWT Gallery" (app is down or not maintained anymore)
- Replace all links to "google code" with link to github
- Fix typo in makingwgtbetter.md
- Update gettingstarted.md (Super Dev Mode is default, plugin usage is deprecated)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/184)
<!-- Reviewable:end -->
