### PR TITLE
"GWT naming" & URI cleanup

### DIFF
--- a/src/main/markdown/doc/latest/FAQ_GettingStarted.md
+++ b/src/main/markdown/doc/latest/FAQ_GettingStarted.md
@@ -43,7 +43,7 @@ developer discussion group](http://groups.google.com/group/Google-Web-Toolkit).
 
 ### How do I install GWT?<a id="How_do_I_install_GWT?"></a>
 
-For step-by-step instructions, see Getting Started: Quick Start [Installing Google Web Toolkit](../../gettingstarted.html).
+For step-by-step instructions, see Getting Started: Quick Start [Installing GWT](../../gettingstarted.html).
 
 ### Is GWT available in my country? Does it work for my language?<a id="Is_GWT_available_in_my_country?_Does_it_work_for_my_language?"></a>
 
@@ -51,7 +51,7 @@ GWT is available in all countries and should work for most languages, though doc
 
 ### Does GWT cost anything?<a id="Does_GWT_cost_anything?"></a>
 
-No, GWT is completely free. In fact, all of [GWT's source code](http://code.google.com/p/google-web-toolkit/) is available under the [Apache 2.0 open source license](../../terms.html).
+No, GWT is completely free. In fact, all of [GWT's source code](https://github.com/gwtproject/gwt) is available under the [Apache 2.0 open source license](../../terms.html).
 
 ### What type of information will GWT collect?<a id="What_type_of_information_will_GWT_collect"></a>
 
@@ -117,7 +117,7 @@ Tracker, and will mark enhancement requests appropriately when we receive them.
 
 ### Where can I find the GWT source code? Can I submit a patch?<a id="Where_can_I_find_the_GWT_source_code?_Can_I_submit_a_patch?"></a>
 
-The GWT source code, licensed under Apache 2.0, is available [here](http://code.google.com/p/google-web-toolkit/). If you are interested in
+The GWT source code, licensed under Apache 2.0, is available [here](https://github.com/gwtproject/gwt). If you are interested in
 contributing a patch, please visit the [Making GWT Better](../../makinggwtbetter.html) guide.
 
 ## Browsers and Servers<a id="Browsers_and_Servers"></a>

--- a/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
@@ -1,6 +1,6 @@
 # Building the UI
 
-In this chapter we'll build a modern looking UI for the **TodoList** application using the [Material Design](http://www.google.es/design/spec/material-design/introduction.html) specifications. We'll be working with the Vaadin gwt-polymer-elements library, a wrapper for the Polymer Paper Elements collection.
+In this chapter we'll build a modern looking UI for the **TodoList** application using the [Material Design](https://material.google.com) specifications. We'll be working with the Vaadin gwt-polymer-elements library, a wrapper for the Polymer Paper Elements collection.
 
 ## Main screen
 

--- a/src/main/markdown/doc/latest/polymer-tutorial/widgets-buildui.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/widgets-buildui.md
@@ -1,7 +1,7 @@
 # Building the UI with GWT Widgets.
 
 
-In this chapter we'll build a modern looking UI for the **TodoList** application using the [Material Design](http://www.google.es/design/spec/material-design/introduction.html) specifications. We'll be working with the Vaadin gwt-polymer-elements library, a wrapper for the Polymer Paper Elements collection.
+In this chapter we'll build a modern looking UI for the **TodoList** application using the [Material Design](https://material.google.com) specifications. We'll be working with the Vaadin gwt-polymer-elements library, a wrapper for the Polymer Paper Elements collection.
 
 ## Main screen
 

--- a/src/main/markdown/doc/latest/tutorial/appengine.md
+++ b/src/main/markdown/doc/latest/tutorial/appengine.md
@@ -3,7 +3,7 @@ Deploy to GAE
 
 At this point, you've created the initial implementation of the StockWatcher application, simulating stock data in the client-side code.
 
-In this section, you'll deploy this application on [Google App Engine](https://developers.google.com/appengine).  Also, you'll learn about some of the App Engine service APIs and use them to personalize the StockWatcher application so that users can log into their Google Account and retrieve their list of stocks.
+In this section, you'll deploy this application on [Google App Engine](https://cloud.google.com/appengine/docs).  Also, you'll learn about some of the App Engine service APIs and use them to personalize the StockWatcher application so that users can log into their Google Account and retrieve their list of stocks.
 
 1.  [Get started with App Engine](#intro)
 2.  [Deploy the application to App Engine](#deploy)
@@ -18,7 +18,7 @@ This tutorial builds on the GWT concepts and the StockWatcher application create
 
 ### Sign up for an App Engine account
 
-[Sign up](https://appengine.google.com) for an App Engine account.  After your account is activated, sign in and create an application.  Make a note of the application ID you choose because you will need this information when you configure the StockWatcher project.  After you've finished with this tutorial you will be able to reuse this application ID for other applications.
+[Sign up](https://console.cloud.google.com/appengine) for an App Engine account.  After your account is activated, sign in and create an application.  Make a note of the application ID you choose because you will need this information when you configure the StockWatcher project.  After you've finished with this tutorial you will be able to reuse this application ID for other applications.
 
 ### Download the App Engine SDK
 
@@ -41,7 +41,7 @@ If you initially created your StockWatcher Eclipse project using the Google Plug
 
 #### Set up a project (without Eclipse)
 
-1.  If you haven't yet, download the [App Engine SDK](https://developers.google.com/appengine/downloads) for Java.
+1.  If you haven't yet, download the [App Engine SDK](https://cloud.google.com/appengine/downloads) for Java.
 2.  Complete the [Build a Sample GWT Application](gettingstarted.html) tutorial,  using webAppCreator to create a GWT application.  Alternatively, If you would like to skip the Build a Sample GWT Application tutorial, then download and unzip [this file](http://code.google.com/p/google-web-toolkit/downloads/detail?name=Tutorial-GettingStarted-2.1.zip).  Edit the gwt.sdk property in the StockWatcher/build.xml, then proceed with the modifications below.
 3.  App Engine requires its own web application deployment descriptor.  Create a file StockWatcher/war/WEB-INF/appengine-web.xml with these contents:
 
@@ -52,9 +52,9 @@ If you initially created your StockWatcher Eclipse project using the Google Plug
         </appengine-web-app>
 
     Substitute your App Engine application ID on the second line. Read more about
-[appengine-web.xml](https://developers.google.com/appengine/docs/java/config/appconfig).
+[appengine-web.xml](https://cloud.google.com/appengine/docs/java/config/appref).
 
-4.  As we will be using [Java Data Objects (JDO)](https://developers.google.com/appengine/docs/java/gettingstarted/usingdatastore) later for storing data, create a file StockWatcher/src/META-INF/jdoconfig.xml with these contents:
+4.  As we will be using [Java Data Objects (JDO)](https://cloud.google.com/appengine/docs/java/gettingstarted/using-datastore-objectify) later for storing data, create a file StockWatcher/src/META-INF/jdoconfig.xml with these contents:
 
         <?xml version="1.0" encoding="utf-8"?>
         <jdoconfig xmlns="http://java.sun.com/xml/ns/jdo/jdoconfig"
@@ -1070,7 +1070,7 @@ stockService.removeStock(symbol, new AsyncCallback<Void>() {
 
 You can repeat the instructions above to run the application [locally](#test) or on [App Engine](#deploy).
 
-If you encounter runtime errors, examine the logs in the [App Engine Administration Console](https://appengine.google.com/).
+If you encounter runtime errors, examine the logs in the [App Engine Administration Console](https://console.cloud.google.com/appengine).
 
 ## More resources
 
@@ -1084,6 +1084,6 @@ Users can now sign in to Google Account and manage their own stock lists in the 
 
 ### Learn more about App Engine
 
-The App Engine [Java Getting Started tutorial](https://developers.google.com/appengine/docs/java/gettingstarted) gives more details on building an App Engine application including topics such as creating a project from scratch, using JSPs, managing different application versions, and more details on the web application descriptor files.
+The App Engine [Java Getting Started tutorial](https://cloud.google.com/appengine/docs/java/gettingstarted/creating-guestbook) gives more details on building an App Engine application including topics such as creating a project from scratch, using JSPs, managing different application versions, and more details on the web application descriptor files.
 
-The App Engine [Java documentation](https://developers.google.com/appengine/docs/java) covers the User service and datastore service in greater detail.  In particular, it documents how to use JPA to access the datastore service.  Other services documented include Memcache, HTTP client, and, Java Mail.  The limitations of the App Engine Java runtime are also itemized.
+The App Engine [Java documentation](https://cloud.google.com/appengine/docs/java/) covers the User service and datastore service in greater detail.  In particular, it documents how to use JPA to access the datastore service.  Other services documented include Memcache, HTTP client, and, Java Mail.  The limitations of the App Engine Java runtime are also itemized.

--- a/src/main/markdown/doc/latest/tutorial/index.md
+++ b/src/main/markdown/doc/latest/tutorial/index.md
@@ -1,7 +1,7 @@
 Tutorials: Overview
 ===
 
-These tutorials are intended for developers who wish to write rich AJAX applications using Google Web Toolkit. You might be a Java developer who would like to be able to apply the software engineering principles of object-oriented programming and leverage the tools in your Java IDE when writing applications for the web. Or you might be a JavaScript guru curious about GWT's ability to generate highly optimized JavaScript.
+These tutorials are intended for developers who wish to write rich AJAX applications using GWT. You might be a Java developer who would like to be able to apply the software engineering principles of object-oriented programming and leverage the tools in your Java IDE when writing applications for the web. Or you might be a JavaScript guru curious about GWT's ability to generate highly optimized JavaScript.
 
 Although a knowledge of HTML, CSS, and Java is assumed, it is not required to run these tutorials.
 
@@ -15,14 +15,14 @@ These tutorials are based on the development of two example applications, such t
 Before you begin these tutorials, we assume that you've done the following:
 
 1.   Installed the Java SDK.
-    *  If you don't have a recent version of the Java SDK installed, download and install [Sun Java Standard Edition SDK](http://java.sun.com/javase/downloads/index.jsp).
+    *  If you don't have a recent version of the Java SDK installed, download and install [Java Standard Edition SDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 2.   Installed Eclipse or your favorite Java IDE.
     *  In these tutorials, we use [Eclipse](http://www.eclipse.org/) because it is open source. However, GWT does not tie you to Eclipse. You can use [IntelliJ](http://www.jetbrains.com/idea/), [NetBeans](http://www.netbeans.org/) or any Java IDE you prefer. If you use a Java IDE other than Eclipse, the screenshots and some of the specific instructions in the tutorial will be different, but the basic GWT concepts will be the same.
     *  If your Java IDE does not include Apache Ant support, you can download and unzip [Ant](http://ant.apache.org) to easily compile and run GWT applications.
 3.   Installed the Google Plugin for Eclipse.
-    *  The [Google Plugin for Eclipse](https://developers.google.com/appengine/docs/java/tools/eclipse) adds functionality to Eclipse for creating and developing GWT applications.
-4.   Downloaded Google Web Toolkit.
-    *  Google Web Toolkit can be downloaded with the Google Plugin for Eclipse.  Alternatively, download the most recent distribution of [Google Web Toolkit](../../../download.html) for your operating system.
+    *  The [Google Plugin for Eclipse](https://developers.google.com/eclipse/docs/getting_started) adds functionality to Eclipse for creating and developing GWT applications.
+4.   Downloaded GWT.
+    *  GWT can be downloaded with the Google Plugin for Eclipse.  Alternatively, download the most recent distribution of [GWT](../../../download.html) for your operating system.
 5.   Unzipped the GWT distribution in directory you want to run it in.
     *  GWT does not have an installation program. All the files you need to run and use GWT are located in the extracted directory.
 
@@ -38,7 +38,7 @@ You may also optionally do the following:
 ### Build a Sample GWT Application
 
 1.   [Build a Sample GWT Application](gettingstarted.html)
-   * Get started with Google Web Toolkit by developing the StockWatcher application from scratch. You'll learn to create a GWT project, build the UI with GWT wigdets and panels, code the client-side functionality in the Java language, debug in development mode, apply CSS styles, compile the Java into JavaScript, and run the application in production mode.
+   * Get started with GWT by developing the StockWatcher application from scratch. You'll learn to create a GWT project, build the UI with GWT wigdets and panels, code the client-side functionality in the Java language, debug in development mode, apply CSS styles, compile the Java into JavaScript, and run the application in production mode.
 
 ### Client-Server Communication
 
@@ -62,7 +62,7 @@ You may also optionally do the following:
 ### Deploying to Google App Engine
 
 1.   [Deploying to Google App Engine](appengine.html)
-    *  Deploy a GWT application to [App Engine](https://developers.google.com/appengine).
+    *  Deploy a GWT application to [App Engine](https://cloud.google.com/appengine/docs).
 
 ### Building Modern Apps with GWT & Polymer
 

--- a/src/main/markdown/gettingstarted.md
+++ b/src/main/markdown/gettingstarted.md
@@ -12,7 +12,7 @@ Getting Started
 ## Prerequisites<a id="prereqs"></a>
 
 1.  You will need the Java SDK version 1.6 or later. If necessary, <a
-    href="http://java.sun.com/javase/downloads/" rel="nofollow">download and
+    href="http://www.oracle.com/technetwork/java/javase/downloads/index.html" rel="nofollow">download and
     install the Java SE Development Kit (JDK)</a> for your platform. Mac users,
     see <a href="http://developer.apple.com/java/">Apple's Java developer
     site</a> to download and install the latest version of the Java Developer


### PR DESCRIPTION
- Change "Google Web Toolkit" to "GWT"
- Change old "Sun"  URI to new "Oracle" Java SE download URI
- Change old appengine URIs to new google cloud URI scheme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/188)
<!-- Reviewable:end -->
