### PR TITLE
Add fully qualified class name to ambigious return type.

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideTesting.md
+++ b/src/main/markdown/doc/latest/DevGuideTesting.md
@@ -320,7 +320,7 @@ Here is an example:
 
 ```
 public class MapsTestSuite extends GWTTestSuite {
-  public static Test suite() {
+  public static junit.framework.Test suite() {
     TestSuite suite = new TestSuite("Test for a Maps Application");
     suite.addTestSuite(MapTest.class); 
     suite.addTestSuite(EventTest.class);


### PR DESCRIPTION
Test is ambiguous as a type name, even within Junit.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/191)

<!-- Reviewable:end -->
