### PR TITLE
Update to create.md

### DIFF
--- a/src/main/markdown/doc/latest/polymer-tutorial/create.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/create.md
@@ -41,7 +41,7 @@ For the **TodoList** project, we'll need to run `webAppCreator` with the followi
 
         $ cd TodoListApp
         $ mvn war:exploded
-        $ mvn gwt:run
+        $ mvn gwt:devmode
 
       _**Tip**: Since the created project is built with Maven, you can import it in Eclipse, IDEA, etc._
 


### PR DESCRIPTION
The new created project from webAppCreator uses the Maven Plugin for GWT there is no `gwt:run` goal, now we must use `gwt:devmode`, like says here https://tbroyer.github.io/gwt-maven-plugin/migrating.html

Sorry if my english is not accurate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/194)
<!-- Reviewable:end -->
