### PR TITLE
Link gss_migration from the TOC and the articles landing page

### DIFF
--- a/src/main/markdown/articles/articles.md
+++ b/src/main/markdown/articles/articles.md
@@ -3,6 +3,10 @@
 Below is a list of articles (most recent first) that have been published about GWT development. If you're interested in contributing an article on a specific GWT topic,
  please [drop us a line](http://groups.google.com/group/Google-Web-Toolkit/post?sendowner=1&_done=/group/Google-Web-Toolkit/about%3F&).
 
+*   [Migrating CssResources from CSS to GSS](gss_migration.html) - _December 2015_
+
+    Explains how to gradually transition your CssResources from CSS over to GSS.
+
 *   [Fragment Merging in the GWT Compiler](fragment_merging.html) - _June 2012_
 
      Explains a GWT compiler option for reducing latency in large GWT applications.

--- a/src/main/markdown/articles/config.xml
+++ b/src/main/markdown/articles/config.xml
@@ -9,7 +9,7 @@
 			<entry name="articles" displayName="Overview" description="A summary of all articles"></entry>
 			<entry name="dom_events_memory_leaks_and_you" displayName="DOM Memory Leaks" description="How GWT tackles memory leaks"></entry>
 			<entry name="dynamic_host_page" displayName="Dynamic Host Page" description="Running GWT in dynamic host pages"></entry>
-			<entry name="gss_migration" displayName="GSS migration" description="Migrating from CssResource to GssResource"></entry>
+			<entry name="gss_migration" displayName="GSS migration" description="Migrating CssResources from CSS to GSS"></entry>
 			<entry name="elemental" displayName="Elemental" description="Elemental"></entry>
 			<entry name="fragment_merging" displayName="Fragment Merging" description="Fragment Merging"></entry>
 			<entry name="gwt-iphone" displayName="GWT iPhone" description="GWT iPhone"></entry>

--- a/src/main/resources/toc.md
+++ b/src/main/resources/toc.md
@@ -117,6 +117,7 @@
       - [Presentations](presentations.html 'Different Presentations on GWT')
       - [Articles](#)
           - [Overview](articles/articles.html)
+          - [GSS Migration](articles/gss_migration.html 'Migrating CssResources from CSS to GSS')
           - [Fragment Merging](articles/fragment_merging.html)
           - [Super Dev Mode](articles/superdevmode.html)
           - [Elemental](articles/elemental.html)


### PR DESCRIPTION
The GSS Migration Guide was only ever linked from the release notes
for 2.8.0 Beta 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/209)
<!-- Reviewable:end -->
