### PR TITLE
Changed link to best practices talk to YouTube link

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideTesting.md
+++ b/src/main/markdown/doc/latest/DevGuideTesting.md
@@ -32,7 +32,7 @@ your GWT app just as they would any other, perhaps even more than usual.
 
 For some tips along these lines take a look at
 the [Best
-Practices For Architecting Your GWT App](http://code.google.com/events/io/2009/sessions/GoogleWebToolkitBestPractices.html) talk given at Google I/O
+Practices For Architecting Your GWT App](https://www.youtube.com/watch?v=PDuhR18-EdM) talk given at Google I/O
 in May of 2009. And keep an eye on this site for more more articles in
 the same vein.
 

--- a/src/main/markdown/doc/latest/DevGuideTesting.md
+++ b/src/main/markdown/doc/latest/DevGuideTesting.md
@@ -31,9 +31,9 @@ separation of concerns, dependency injection and the like will benefit
 your GWT app just as they would any other, perhaps even more than usual.
 
 For some tips along these lines take a look at
-the [Best
-Practices For Architecting Your GWT App](https://www.youtube.com/watch?v=PDuhR18-EdM) talk given at Google I/O
-in May of 2009. And keep an eye on this site for more more articles in
+the *Best Practices For Architecting Your GWT App* 
+([video](https://www.youtube.com/watch?v=PDuhR18-EdM) or 
+[slides](http://dl.google.com/io/2009/pres/Th_0200_GoogleWebToolkitArchitecture-BestPracticesForArchitectingYourGWTApp.pdf)) given at Google I/O in May of 2009. And keep an eye on this site for more more articles in
 the same vein.
 
 ## Creating a Test Case<a id="DevGuideJUnitCreation"></a>

--- a/src/main/markdown/doc/latest/DevGuideTesting.md
+++ b/src/main/markdown/doc/latest/DevGuideTesting.md
@@ -31,7 +31,7 @@ separation of concerns, dependency injection and the like will benefit
 your GWT app just as they would any other, perhaps even more than usual.
 
 For some tips along these lines take a look at
-the *Best Practices For Architecting Your GWT App* 
+the *Best Practices For Architecting Your GWT App* talk
 ([video](https://www.youtube.com/watch?v=PDuhR18-EdM) or 
 [slides](http://dl.google.com/io/2009/pres/Th_0200_GoogleWebToolkitArchitecture-BestPracticesForArchitectingYourGWTApp.pdf)) given at Google I/O in May of 2009. And keep an eye on this site for more more articles in
 the same vein.

--- a/src/main/markdown/doc/latest/DevGuideTesting.md
+++ b/src/main/markdown/doc/latest/DevGuideTesting.md
@@ -31,9 +31,9 @@ separation of concerns, dependency injection and the like will benefit
 your GWT app just as they would any other, perhaps even more than usual.
 
 For some tips along these lines take a look at
-the *Best Practices For Architecting Your GWT App* 
-([video](https://www.youtube.com/watch?v=PDuhR18-EdM) or 
-[slides](http://dl.google.com/io/2009/pres/Th_0200_GoogleWebToolkitArchitecture-BestPracticesForArchitectingYourGWTApp.pdf)) given at Google I/O in May of 2009. And keep an eye on this site for more more articles in
+the [Best
+Practices For Architecting Your GWT App](https://www.youtube.com/watch?v=PDuhR18-EdM) talk given at Google I/O
+in May of 2009. And keep an eye on this site for more more articles in
 the same vein.
 
 ## Creating a Test Case<a id="DevGuideJUnitCreation"></a>


### PR DESCRIPTION
Because the google events page throws a 404, I have updated the docs with a direct link to the video on YouTube

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/216)
<!-- Reviewable:end -->
