### PR TITLE
Remove ^C control chars from index.html

### DIFF
--- a/src/main/site/index.html
+++ b/src/main/site/index.html
@@ -114,8 +114,8 @@
                         <div class="col col-2_3">
 
                             <p>GWT is used by many products at Google, including Google AdWords
-                                and Google Wallet.
-                                It's open source, completely free, and used by thousands of
+                                and Google Wallet.
+                                It's open source, completely free, and used by thousands of
                                 enthusiastic developers
                                 around the world.</p>
 
@@ -145,7 +145,7 @@
 
                             <p>It is intended for developers interested in contributing to GWT,
                                 and for keeping people
-                                informed on new and upcoming changes to GWT, GWT related events
+                                informed on new and upcoming changes to GWT, GWT related events
                                 and other news.</p>
 
                         </div>
@@ -167,9 +167,9 @@
                             <a href="overview.html">
                                 <i class="icon_overview"></i>
 
-                                <h2>Learn about GWT</h2>
+                                <h2>Learn about GWT</h2>
 
-                                <p>The features and tools it offers, and how you can quickly
+                                <p>The features and tools it offers, and how you can quickly
                                     develop performance AJAX
                                     applications across all major browsers.</p>
                             </a>
@@ -181,8 +181,8 @@
 
                                 <h2>Download</h2>
 
-                                <p>Download and install the tools in GWT, including the SDK,
-                                    Speed Tracer, and the Google Plugin for Eclipse.</p>
+                                <p>Download and install the tools in GWT, including the SDK,
+                                    Speed Tracer, and the Google Plugin for Eclipse.</p>
                             </a>
                         </div>
 
@@ -193,11 +193,11 @@
                                 <i class="icon_getstarted"></i>
                                 <h2>Get started</h2>
 
-                                <p>Walk through the first steps needed to get a web application
+                                <p>Walk through the first steps needed to get a web application
                                     up and running.</p>
 
-                                <p>Download and install the tools in GWT, including the SDK,
-                                    Speed Tracer, and the Google Plugin for Eclipse.</p>
+                                <p>Download and install the tools in GWT, including the SDK,
+                                    Speed Tracer, and the Google Plugin for Eclipse.</p>
                             </a>
                         </div>
 


### PR DESCRIPTION
Apparently, this is the only file and the only control char
(I'd blame console editing and doing Ctrl+V Ctrl+C)

Fixes #224

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/225)
<!-- Reviewable:end -->
