### PR TITLE
Recommend LayoutPanel#setWidgetVisible to hide widgets

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideUiPanels.md
+++ b/src/main/markdown/doc/latest/DevGuideUiPanels.md
@@ -475,15 +475,14 @@ won't behave quite as expected: the widget will indeed be made invisible, but
 it will tend to consume mouse events (actually, it's the container element that
 is doing so).
 
-To work around this, you can get the container element directly using
-[LayoutPanel.getWidgetContainerElement(Widget)](/javadoc/latest/com/google/gwt/user/client/ui/LayoutPanel.html#getWidgetContainerElement\(com.google.gwt.user.client.ui.Widget\)), and set its visibility
-directly:
+To work around this, you need to use
+[LayoutPanel.setWidgetVisible(Widget,boolean)](/javadoc/latest/com/google/gwt/user/client/ui/LayoutPanel.html#setWidgetVisible-com.google.gwt.user.client.ui.Widget-boolean-):
 
 ```
 LayoutPanel panel = ...;
 Widget child;
 panel.add(child);
-UIObject.setVisible(panel.getWidgetContainerElement(child), false);
+panel.setWidgetVisible(child, false);
 ```
 
 ### Using a LayoutPanel without RootLayoutPanel


### PR DESCRIPTION
…instead of UiObject.setVisible on the Layout wrapper element
returned by LayoutPanel#getWidgetContainerElement.

Fixes gwtproject/gwt#7544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/227)
<!-- Reviewable:end -->
