### PR TITLE
Reference to build and run instructions

### DIFF
--- a/src/main/markdown/makinggwtbetter.md
+++ b/src/main/markdown/makinggwtbetter.md
@@ -564,22 +564,10 @@ you can clone the repository:
 
 `git clone https://github.com/gwtproject/gwt-site`
 
-The source code for this webpage will be found in *src/main/markdown*. You can edit existing files and add new ones. If you want to see your changes you will need to run:
-
-`mvn clean install`
-
-After that you can go to *target/generated-site* and see the generated site.
-
-You can also launch the embedded Jetty server with
-
-```
-mvn jetty:run
-```
-
-and point your browser to [http://localhost:8080](http://localhost:8080).
+The source code for this webpage will be found in *src/main/markdown*. You can edit existing files and add new ones. For [building](https://github.com/gwtproject/gwt-site#building) and [running](https://github.com/gwtproject/gwt-site#running-locally) the pages see https://github.com/gwtproject/gwt-site#building
 
 If you think your change is ready to be published on gwtproject.org you can send us
-your changes with a pull request to http://github.com/gwtproject/gwt-site.
+your changes with a pull request to https://github.com/gwtproject/gwt-site.
 
 If you wish to contribute to the GWT code used on the site (to improve navigation), then you should
 

--- a/src/main/markdown/makinggwtbetter.md
+++ b/src/main/markdown/makinggwtbetter.md
@@ -564,7 +564,7 @@ you can clone the repository:
 
 `git clone https://github.com/gwtproject/gwt-site`
 
-The source code for this webpage will be found in *src/main/markdown*. You can edit existing files and add new ones. For [building](https://github.com/gwtproject/gwt-site#building) and [running](https://github.com/gwtproject/gwt-site#running-locally) the pages see https://github.com/gwtproject/gwt-site#building
+The source code is located in *src/main/markdown*. Instructions to test the changes locally can be found in the [README](https://github.com/gwtproject/gwt-site).
 
 If you think your change is ready to be published on gwtproject.org you can send us
 your changes with a pull request to https://github.com/gwtproject/gwt-site.


### PR DESCRIPTION
The build and run instructions on the github readme.md are more up to date than the webpage. To avoid redundant descriptions and easier maintainance simply link to the building and run section of the readme.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/228)
<!-- Reviewable:end -->
