### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#GWT Documentation
+# GWT Documentation
 
 * GWT documentation is published under http://www.gwtproject.org/doc/latest/DevGuide.html
 
-##Reference
+## Reference
 
 * Markdown processor: https://github.com/sirthias/pegdown
 
-##Adding content
+## Adding content
 
 * See: http://www.gwtproject.org/makinggwtbetter.html#webpage
 
-##Building
+## Building
 
 If you have Grunt installed :
 * build the assets using Grunt: `grunt`
@@ -21,7 +21,7 @@ If you don't have Grunt installer :
 * build the assets using Maven and Grunt plugin: `mvn clean install -Pgrunt`
 * after that you will find the generated documentation in `target/generated-site/`.
 
-###Running locally
+### Running locally
 Run the site locally for easy visual testing
 
 * Change to the `target/generated-site` folder.

--- a/src/main/markdown/articles/articles.md
+++ b/src/main/markdown/articles/articles.md
@@ -1,4 +1,4 @@
-#Overview
+# Overview
 
 Below is a list of articles (most recent first) that have been published about GWT development. If you're interested in contributing an article on a specific GWT topic,
  please [drop us a line](http://groups.google.com/group/Google-Web-Toolkit/post?sendowner=1&_done=/group/Google-Web-Toolkit/about%3F&).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/231)
<!-- Reviewable:end -->
