### PR TITLE
Fix broken link in public documentation DevGuideUiCustomCells.html

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideUiCustomCells.md
+++ b/src/main/markdown/doc/latest/DevGuideUiCustomCells.md
@@ -20,7 +20,7 @@ before continuing.
 ## Implementing the render() Method<a id="cell-render"></a>
 
 The core method that all Cells must implement is the
-[Cell#render(Context, C value, SafeHtmlBuilder)](/javadoc/latest/com/google/gwt/cell/client/Cell.html#render\(com.google.gwt.cell.client.Cell.Context, C, com.google.gwt.safehtml.shared.SafeHtmlBuilder\))
+[Cell.render(Context, C value, SafeHtmlBuilder)](/javadoc/latest/com/google/gwt/cell/client/Cell.html#render-com.google.gwt.cell.client.Cell.Context-C-com.google.gwt.safehtml.shared.SafeHtmlBuilder-)
 method, which renders the parameterized `value` into the `SafeHtmlBuilder`.  In some cases, you will only need to render
 simple HTML, such as a single `div` with some content.  In other cases, you might need to render a complex HTML structure, such as the one
 in the [CellList](http://samples.gwtproject.org/samples/Showcase/Showcase.html#!CwCellList) example, which contains an image and two lines of

--- a/src/main/markdown/doc/latest/DevGuideUiCustomCells.md
+++ b/src/main/markdown/doc/latest/DevGuideUiCustomCells.md
@@ -20,7 +20,7 @@ before continuing.
 ## Implementing the render() Method<a id="cell-render"></a>
 
 The core method that all Cells must implement is the
-[Cell.render(Context, C value, SafeHtmlBuilder)](/javadoc/latest/com/google/gwt/cell/client/Cell.html#render-com.google.gwt.cell.client.Cell.Context-C-com.google.gwt.safehtml.shared.SafeHtmlBuilder-)
+[Cell#render(Context, C value, SafeHtmlBuilder)](/javadoc/latest/com/google/gwt/cell/client/Cell.html#render-com.google.gwt.cell.client.Cell.Context-C-com.google.gwt.safehtml.shared.SafeHtmlBuilder-)
 method, which renders the parameterized `value` into the `SafeHtmlBuilder`.  In some cases, you will only need to render
 simple HTML, such as a single `div` with some content.  In other cases, you might need to render a complex HTML structure, such as the one
 in the [CellList](http://samples.gwtproject.org/samples/Showcase/Showcase.html#!CwCellList) example, which contains an image and two lines of


### PR DESCRIPTION
This page:
  http://www.gwtproject.org/doc/latest/DevGuideUiCustomCells.html
says
  "The core method that all Cells must implement is the [Cell#render(Context, C value, SafeHtmlBuilder)](/javadoc/latest/com/google/gwt/cell/client/Cell.html#render(com.google.gwt.cell.client.Cell.Context, C, com.google.gwt.safehtml.shared.SafeHtmlBuilder)) method, which ..."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/244)
<!-- Reviewable:end -->
