### PR TITLE
Add information about support for java.util.stream

### DIFF
--- a/src/main/markdown/doc/latest/RefJreEmulation.md
+++ b/src/main/markdown/doc/latest/RefJreEmulation.md
@@ -13,6 +13,7 @@ Note that in some cases, only a subset of methods is supported for a given type.
   <li><a href="#Package_java_sql">java.sql</a></li>
   <li><a href="#Package_java_util">java.util</a></li>
   <li><a href="#Package_java_util_logging">java.util.logging</a></li>
+  <li><a href="#Package_java_util_stream">java.util.stream</a></li>
 </ol>
 
 <h2 id="Package_java_lang">Package java.lang</h2>
@@ -537,3 +538,5 @@ Note that in some cases, only a subset of methods is supported for a given type.
   <dd>getGlobal(), getLogger(String), addHandler(Handler), config(String), config(Supplier), fine(String), fine(Supplier), finer(String), finer(Supplier), finest(String), finest(Supplier), info(String), info(Supplier), warning(String), warning(Supplier), severe(String), severe(Supplier), getHandlers(), getLevel(), getName(), getParent(), getUseParentHandlers(), isLoggable(Level), log(Level, String), log(Level, Supplier), log(Level, String, Throwable), log(Level, Throwable, Supplier), log(LogRecord), removeHandler(Handler), setLevel(Level), setParent(Logger), setUseParentHandlers(boolean)</dd>
 </dl>
 
+<h2 id="Package_java_util_stream">Package java.util.stream</h2>
+All supported


### PR DESCRIPTION
I'm not sure the best way to describe support for java.util.stream but it needs to be mentioned. We have an automated process that reads this page and updates the Access Rules in Eclipse but it misses out java.util.stream completely so I've had to add it in manually for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/261)
<!-- Reviewable:end -->
