### PR TITLE
Fix code format and spelling errors in tutorial

### DIFF
--- a/src/main/markdown/doc/latest/tutorial/JSON.md
+++ b/src/main/markdown/doc/latest/tutorial/JSON.md
@@ -40,7 +40,6 @@ When you encode the stock data for StockWatcher in JSON format, it will look som
     "change": 0.05
   }
 ]
-
 ```
 
 ##  Creating a source of JSON data on your local server <a id="server"></a>
@@ -50,7 +49,7 @@ When you encode the stock data for StockWatcher in JSON format, it will look som
 In the original StockWatcher implementation, you created a StockPrice class and used the refreshWatchList method to generate random stock data and then call the updateTable method to populate StockWatcher's flex table.
 
 ```
-/**
+  /**
    * Generate random stock prices.
    */
   private void refreshWatchList() {
@@ -68,7 +67,6 @@ In the original StockWatcher implementation, you created a StockPrice class and 
 
     updateTable(prices);
   }
-
 ```
 
 In this tutorial, you'll create a servlet to generate the stock data in JSON format. Then you'll make an HTTP call to retrieve the JSON data from the server. You'll use JSNI and GWT overlay types to work with the JSON data while writing the client-side code.
@@ -90,36 +88,36 @@ To serve up hypothetical stock quotes in JSON format, you'll create a servlet. T
 ```
 package com.google.gwt.sample.stockwatcher.server;
 
-    import java.io.IOException;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Random;
 
-    import javax.servlet.ServletException;
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-    public class JsonStockData extends HttpServlet {
+public class JsonStockData extends HttpServlet {
 
-      private static final double MAX_PRICE = 100.0; // $100.00
+  private static final double MAX_PRICE = 100.0; // $100.00
   private static final double MAX_PRICE_CHANGE = 0.02; // +/- 2%
 
-      @Override
+  @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp)
       throws ServletException, IOException {
 
-        Random rnd = new Random();
+    Random rnd = new Random();
 
-        PrintWriter out = resp.getWriter();
+    PrintWriter out = resp.getWriter();
     out.println('[');
     String[] stockSymbols = req.getParameter("q").split(" ");
     boolean firstSymbol = true;
     for (String stockSymbol : stockSymbols) {
 
-          double price = rnd.nextDouble() * MAX_PRICE;
+      double price = rnd.nextDouble() * MAX_PRICE;
       double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
 
-          if (firstSymbol) {
+      if (firstSymbol) {
         firstSymbol = false;
       } else {
         out.println("  ,");
@@ -139,8 +137,7 @@ import javax.servlet.http.HttpServletResponse;
     out.flush();
   }
 
-    }
-
+}
 ```
 
 ### Including the server-side code in the GWT module
@@ -167,25 +164,25 @@ Because you've mapped the StockPriceService to "stockPrices" and the module rena
     PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
     "http://java.sun.com/dtd/web-app_2_3.dtd">
 
-    <web-app>
+<web-app>
 
-      <!-- Default page to serve -->
+  <!-- Default page to serve -->
   <welcome-file-list>
     <welcome-file>StockWatcher.html</welcome-file>
   </welcome-file-list>
 
-      <!-- Servlets -->
- <servlet>
+  <!-- Servlets -->
+  <servlet>
     <servlet-name>jsonStockData</servlet-name>
     <servlet-class>com.google.gwt.sample.stockwatcher.server.JsonStockData</servlet-class>
   </servlet>
 
-      <servlet-mapping>
+  <servlet-mapping>
     <servlet-name>jsonStockData</servlet-name>
     <url-pattern>/stockwatcher/stockPrices</url-pattern>
   </servlet-mapping>
 
-    </web-app>
+</web-app>
 ```
 
 ### Testing your ability to retrieve JSON data from the server
@@ -205,7 +202,7 @@ Because you've mapped the StockPriceService to "stockPrices" and the module rena
 At this point, you've verified that you are able to get JSON data from a server.
 Later in this section, you'll code the HTTP GET request to the server.
 First, focus on working with the JSON-encoded text that's returned to the client-side code.
-Two techiques you'll use are JSNI (JavaScript Native Interface) and GWT overlay types.
+Two techniques you'll use are JSNI (JavaScript Native Interface) and GWT overlay types.
 
 This is the JSON data coming back from the server.
 
@@ -222,7 +219,7 @@ This is the JSON data coming back from the server.
 First, you'll use [JsonUtils.safeEval()](/javadoc/latest/com/google/gwt/core/client/JsonUtils.html) to convert the JSON string into JavaScript objects. Then, you'll be able to write methods to access those objects.
 
 ```
-// JSNI methods to get stock data.
+  // JSNI methods to get stock data.
   public final native String getSymbol() /*-{ return this.symbol; }-*/;
   public final native double getPrice() /*-{ return this.price; }-*/;
   public final native double getChange() /*-{ return this.change; }-*/;
@@ -272,18 +269,18 @@ The new StockData class will be an overlay type which overlays the existing Java
 ```
 package com.google.gwt.sample.stockwatcher.client;
 
-    import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JavaScriptObject;
 
-    class StockData extends JavaScriptObject {                              // <span style="color:black;">**(1)**</span>
+class StockData extends JavaScriptObject {                              // <span style="color:black;">**(1)**</span>
   // Overlay types always have protected, zero argument constructors.
   protected StockData() {}                                              // <span style="color:black;">**(2)**</span>
 
-      // JSNI methods to get stock data.
+  // JSNI methods to get stock data.
   public final native String getSymbol() /*-{ return this.symbol; }-*/; // <span style="color:black;">**(3)**</span>
   public final native double getPrice() /*-{ return this.price; }-*/;
   public final native double getChange() /*-{ return this.change; }-*/;
 
-      // Non-JSNI method to return change percentage.                       // <span style="color:black;">**(4)**</span>
+  // Non-JSNI method to return change percentage.                       // <span style="color:black;">**(4)**</span>
   public final double getChangePercent() {
     return 100.0 * getChange() / getPrice();
   }
@@ -355,26 +352,26 @@ import com.google.gwt.core.client.GWT;
 
 ```
 private void refreshWatchList() {
-    if (stocks.size() == 0) {
-      return;
+  if (stocks.size() == 0) {
+    return;
+  }
+
+  String url = JSON_URL;
+
+  // Append watch list stock symbols to query URL.
+  Iterator<String> iter = stocks.iterator();
+  while (iter.hasNext()) {
+    url += iter.next();
+    if (iter.hasNext()) {
+      url += "+";
     }
+  }
 
-        String url = JSON_URL;
+  url = URL.encode(url);
 
-        // Append watch list stock symbols to query URL.
-    Iterator<String> iter = stocks.iterator();
-    while (iter.hasNext()) {
-      url += iter.next();
-      if (iter.hasNext()) {
-        url += "+";
-      }
-    }
+  // TODO Send request to server and handle errors.
 
-        url = URL.encode(url);
-
-        // TODO Send request to server and handle errors.
-
-      }
+}
 ```
 
    *  Eclipse flags Iterator and URL.
@@ -383,8 +380,8 @@ private void refreshWatchList() {
 ```
 import com.google.gwt.http.client.URL;
 import java.util.Iterator;
-
 ```
+
 ### Asynchronous HTTP
 
 To get the JSON text from the server, you'll use the HTTP client classes in the com.google.gwt.http.client package. These classes contain the functionality for making asynchronous HTTP requests.
@@ -396,21 +393,19 @@ The HTTP types are contained within separate GWT modules that StockWatcher needs
 
 ```
 <!-- Other module inherits -->
-  <inherits name="com.google.gwt.http.HTTP" />
-
+<inherits name="com.google.gwt.http.HTTP" />
 ```
 2.
     *  Open StockWatcher.java and include the following import declarations. Declare the imports for the following Java types.
 
 ```
-
 import com.google.gwt.http.client.Request;
 import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.http.client.RequestException;
 import com.google.gwt.http.client.Response;
-
 ```
+
 ### Building a custom HTTP request
 
 To send a request, you'll create an instance of the RequestBuilder object.
@@ -428,28 +423,30 @@ The RequestCallback interface is analogous to the AsyncCallback interface in GWT
 
     ```
     // Send request to server and catch any errors.
-        RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
+    RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
     
-            try {
-          Request request = builder.sendRequest(null, new RequestCallback() {
-            public void onError(Request request, Throwable exception) {
-              displayError("Couldn't retrieve JSON");
-            }
+    try {
+      Request request = builder.sendRequest(null, new RequestCallback() {
+          public void onError(Request request, Throwable exception) {
+            displayError("Couldn't retrieve JSON");
+          }
     
-                public void onResponseReceived(Request request, Response response) {
-              if (200 == response.getStatusCode()) {
-                updateTable(JsonUtils.<JsArray<StockData>>safeEval(response.getText()));
-              } else {
-                displayError("Couldn't retrieve JSON (" + response.getStatusText()
-                    + ")");
-              }
+          public void onResponseReceived(Request request, Response response) {
+            if (200 == response.getStatusCode()) {
+              updateTable(JsonUtils.<JsArray<StockData>>safeEval(response.getText()));
+            } else {
+              displayError("Couldn't retrieve JSON (" + response.getStatusText()
+                  + ")");
             }
-          });
-        } catch (RequestException e) {
-          displayError("Couldn't retrieve JSON");
-        }
+          }
+      });
+    } catch (RequestException e) {
+      displayError("Couldn't retrieve JSON");
+    }
     ```
+
       *  This is where we use `JsonUtils.safeEval()` to convert the JSON string into JavaScript objects.
+
 2.  You receive two compile errors which you will resolve in a minute.
 
 #### Modify the updateTable method
@@ -483,14 +480,14 @@ import com.google.gwt.core.client.JsArray;
 
 ```
 private void updateTable(StockData price) {
-    // Make sure the stock is still in the stock table.
-    if (!stocks.contains(price.getSymbol())) {
-      return;
-    }
+  // Make sure the stock is still in the stock table.
+  if (!stocks.contains(price.getSymbol())) {
+    return;
+  }
 
-        ...
+  ...
 
-      }
+}
 
 ```
 
@@ -502,15 +499,14 @@ If something breaks along the way (for example, if the server is offline, or the
     *  Set the text for the error message and make the Label widget visible.
 
 ```
-/**
-       * If can't get JSON, display error message.
-       * @param error
+  /**
+   * If can't get JSON, display error message.
+   * @param error
    */
   private void displayError(String error) {
     errorMsgLabel.setText("Error: " + error);
     errorMsgLabel.setVisible(true);
   }
-
 ```
 
 2.  Eclipse flags errorMsgLabel.
@@ -520,18 +516,17 @@ If something breaks along the way (for example, if the server is offline, or the
 
 ```
 private void updateTable(JsArray<StockData> prices) {
-    for (int i=0; i < prices.length(); i++) {
-      updateTable(prices.get(i));
-    }
-
-        // Display timestamp showing last refresh.
-    lastUpdatedLabel.setText("Last update : " +
-        DateTimeFormat.getMediumDateTimeFormat().format(new Date()));
-
-        // Clear any errors.
-    errorMsgLabel.setVisible(false);
+  for (int i=0; i < prices.length(); i++) {
+    updateTable(prices.get(i));
   }
 
+  // Display timestamp showing last refresh.
+  lastUpdatedLabel.setText("Last update : " +
+      DateTimeFormat.getMediumDateTimeFormat().format(new Date()));
+
+  // Clear any errors.
+  errorMsgLabel.setVisible(false);
+}
 ```
 
 #### Displaying error messages
@@ -546,7 +541,7 @@ In order to display the error, you will need a new UI component; you'll implemen
   color: red;
 }
 
-    .errorMessage {
+.errorMessage {
   color: red;
 }
 ```
@@ -556,7 +551,7 @@ In order to display the error, you will need a new UI component; you'll implemen
 
 ```
 private ArrayList<String> stocks = new ArrayList<String>();
-  private Label errorMsgLabel = new Label();
+private Label errorMsgLabel = new Label();
 ```
 
 3.  Initialize the errorMsgLabel when StockWatcher launches.
@@ -564,20 +559,19 @@ private ArrayList<String> stocks = new ArrayList<String>();
     *  Add the error message to the Main panel above the stocksFlexTable.
 
 ```
-// Assemble Add Stock panel.
+    // Assemble Add Stock panel.
     addPanel.add(newSymbolTextBox);
     addPanel.add(addButton);
     addPanel.addStyleName("addPanel");
 
-        // Assemble Main panel.
+    // Assemble Main panel.
     errorMsgLabel.setStyleName("errorMessage");
     errorMsgLabel.setVisible(false);
 
-        mainPanel.add(errorMsgLabel);
+    mainPanel.add(errorMsgLabel);
     mainPanel.add(stocksFlexTable);
     mainPanel.add(addPanel);
     mainPanel.add(lastUpdatedLabel);
-
 ```
 
 ### Test the HTTP request and error handling

--- a/src/main/markdown/doc/latest/tutorial/JSON.md
+++ b/src/main/markdown/doc/latest/tutorial/JSON.md
@@ -223,7 +223,6 @@ First, you'll use [JsonUtils.safeEval()](/javadoc/latest/com/google/gwt/core/cli
   public final native String getSymbol() /*-{ return this.symbol; }-*/;
   public final native double getPrice() /*-{ return this.price; }-*/;
   public final native double getChange() /*-{ return this.change; }-*/;
-
 ```
 
 For the latter, you'll use JSNI. When the client-side code is compiled to JavaScript, the Java methods are replaced with the JavaScript exactly as you write it inside the tokens.
@@ -271,16 +270,16 @@ package com.google.gwt.sample.stockwatcher.client;
 
 import com.google.gwt.core.client.JavaScriptObject;
 
-class StockData extends JavaScriptObject {                              // <span style="color:black;">**(1)**</span>
+class StockData extends JavaScriptObject {                              // (1)
   // Overlay types always have protected, zero argument constructors.
-  protected StockData() {}                                              // <span style="color:black;">**(2)**</span>
+  protected StockData() {}                                              // (2)
 
   // JSNI methods to get stock data.
-  public final native String getSymbol() /*-{ return this.symbol; }-*/; // <span style="color:black;">**(3)**</span>
+  public final native String getSymbol() /*-{ return this.symbol; }-*/; // (3)
   public final native double getPrice() /*-{ return this.price; }-*/;
   public final native double getChange() /*-{ return this.change; }-*/;
 
-  // Non-JSNI method to return change percentage.                       // <span style="color:black;">**(4)**</span>
+  // Non-JSNI method to return change percentage.                       // (4)
   public final double getChangePercent() {
     return 100.0 * getChange() / getPrice();
   }

--- a/src/main/markdown/doc/latest/tutorial/JUnit.md
+++ b/src/main/markdown/doc/latest/tutorial/JUnit.md
@@ -70,19 +70,19 @@ import com.google.gwt.junit.client.GWTTestCase;
 /**
  * GWT JUnit tests must extend GWTTestCase.
  */
-public class StockWatcherTest extends GWTTestCase {                       // <span style="color:black;">**(1)**</span>
+public class StockWatcherTest extends GWTTestCase {                       // (1)
 
   /**
    * Must refer to a valid module that sources this class.
    */
-  public String getModuleName() {                                         // <span style="color:black;">**(2)**</span>
+  public String getModuleName() {                                         // (2)
     return "com.google.gwt.sample.stockwatcher.StockWatcher";
   }
 
   /**
    * Add as many tests as you like.
    */
-  public void testSimple() {                                              // <span style="color:black;">**(3)**</span>
+  public void testSimple() {                                              // (3)
     assertTrue(true);
   }
 

--- a/src/main/markdown/doc/latest/tutorial/JUnit.md
+++ b/src/main/markdown/doc/latest/tutorial/JUnit.md
@@ -28,7 +28,7 @@ This tutorial builds on the GWT concepts and the StockWatcher application create
 2.  Unzip the file.
 3.  Import the project into Eclipse
 
-        1.  From the `File` menu, select the  `Import...` menu option.
+    1.  From the `File` menu, select the  `Import...` menu option.
     2.  Select the import source General > Existing Projects into Workspace. Click the `Next` button.
     3.  For the root directory, browse to and select the StockWatcher directory (from the unzipped file). Click the `Finish` button.
 
@@ -61,33 +61,32 @@ This is where you will write the unit tests for StockWatcher.
 Currently it contains a single, simple test: the method testSimple.
 
 1.  Open the StockWatcherTest.java file.
-        *
 
 ```
 package com.google.gwt.sample.stockwatcher.client;
 
-    import com.google.gwt.junit.client.GWTTestCase;
+import com.google.gwt.junit.client.GWTTestCase;
 
-    /**
-     * GWT JUnit tests must extend GWTTestCase.
+/**
+ * GWT JUnit tests must extend GWTTestCase.
  */
 public class StockWatcherTest extends GWTTestCase {                       // <span style="color:black;">**(1)**</span>
 
-      /**
-       * Must refer to a valid module that sources this class.
+  /**
+   * Must refer to a valid module that sources this class.
    */
   public String getModuleName() {                                         // <span style="color:black;">**(2)**</span>
     return "com.google.gwt.sample.stockwatcher.StockWatcher";
   }
 
-      /**
-       * Add as many tests as you like.
+  /**
+   * Add as many tests as you like.
    */
   public void testSimple() {                                              // <span style="color:black;">**(3)**</span>
     assertTrue(true);
   }
 
-    }
+}
 ```
 
 #### Notes
@@ -134,8 +133,8 @@ with the path to junit on your system.
     *  The simpleTest executes without error.
 
 ```
-&#91;junit&#93; Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
-&#91;junit&#93; Tests run: 1, Failures: 0, Errors: 0, Time elapsed: 15.851 sec
+[junit] Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
+[junit] Tests run: 1, Failures: 0, Errors: 0, Time elapsed: 15.851 sec
 ```
 
 4.  Run the JUnit test in production mode.
@@ -144,8 +143,8 @@ with the path to junit on your system.
     *  The simpleTest executes without error.
 
 ```
-&#91;junit&#93; Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
-&#91;junit&#93; Tests run: 1, Failures: 0, Errors: 0, Time elapsed: 37.042 sec
+[junit] Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
+[junit] Tests run: 1, Failures: 0, Errors: 0, Time elapsed: 37.042 sec
 ```
 
 ### In Eclipse (using the Google Pluging for Eclipse)
@@ -206,7 +205,7 @@ However, to learn the process of setting up JUnit tests in GWT, in this tutorial
 
 ```
 /**
-     * Verify that the instance fields in the StockPrice class are set correctly.
+ * Verify that the instance fields in the StockPrice class are set correctly.
  */
 public void testStockPriceCtor() {
   String symbol = "XYZ";
@@ -214,7 +213,7 @@ public void testStockPriceCtor() {
   double change = 2.0;
   double changePercent = 100.0 * change / price;
 
-      StockPrice sp = new StockPrice(symbol, price, change);
+  StockPrice sp = new StockPrice(symbol, price, change);
   assertNotNull(sp);
   assertEquals(symbol, sp.getSymbol());
   assertEquals(price, sp.getPrice(), 0.001);
@@ -227,8 +226,8 @@ public void testStockPriceCtor() {
     *  Both tests should pass.
 
 ```
-&#91;junit&#93; Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
-&#91;junit&#93; Tests run: 2, Failures: 0, Errors: 0, Time elapsed: 16.601 sec
+[junit] Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
+[junit] Tests run: 2, Failures: 0, Errors: 0, Time elapsed: 16.601 sec
 ```
 
 ##  Resolving problems identified in unit tests <a id="resolve"></a>
@@ -240,9 +239,8 @@ To see what happens when a unit test fails, you'll reintroduce the arithmetic bu
 
 ```
 public double getChangePercent() {
-    return 10.0 * this.change / this.price;
-  }
-
+  return 10.0 * this.change / this.price;
+}
 ```
 
 2.  Run StockWatcherTest in development mode (either in Eclipse of from the command line).
@@ -256,7 +254,7 @@ public double getChangePercent() {
 Testsuite: com.google.gwt.sample.stockwatcher.client.StockWatcherTest
 Tests run: 2, Failures: 1, Errors: 0, Time elapsed: 16.443 sec
 
-    Testcase: testSimple took 16.238 sec
+Testcase: testSimple took 16.238 sec
 Testcase: testStockPriceCtor took 0.155 sec
   FAILED
 Remote test failed at 172.29.212.75 / Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.1) Gecko/2008070208 Firefox/3.0.1
@@ -276,8 +274,8 @@ tests and `reports/htmlunit.prod/` directory for production mode tests.
     *  Both the JUnit tests should complete successfully again.
 
 ```
-&#91;junit&#93; Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
-&#91;junit&#93; Tests run: 2, Failures: 0, Errors: 0, Time elapsed: 16.114 sec
+[junit] Running com.google.gwt.sample.stockwatcher.client.StockWatcherTest
+[junit] Tests run: 2, Failures: 0, Errors: 0, Time elapsed: 16.114 sec
 ```
 
 **Best Practices:** Because there can be subtle differences between the way GWT applications work when compiled to JavaScript and when running as Java bytecode, make sure you run your unit tests in both development and production modes as you develop your application. Be aware, though, that if your test cases fail when running in production mode, you won't get the full stack trace that you see in development mode.

--- a/src/main/markdown/doc/latest/tutorial/RPC.md
+++ b/src/main/markdown/doc/latest/tutorial/RPC.md
@@ -102,7 +102,7 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 @RemoteServiceRelativePath("stockPrices")
 public interface StockPriceService extends RemoteService {
 
-      StockPrice[] getPrices(String[] symbols);
+  StockPrice[] getPrices(String[] symbols);
 }
 ```
 
@@ -143,10 +143,10 @@ The service implementation runs on the server as Java bytecode; it's not transla
 
         public class StockPriceServiceImpl extends RemoteServiceServlet implements StockPriceService {
 
-            public StockPrice[] getPrices(String[] symbols) {
-                // TODO Auto-generated method stub
-                return null;
-            }
+          public StockPrice[] getPrices(String[] symbols) {
+            // TODO Auto-generated method stub
+            return null;
+          }
         }
 
 ### Write the server-side implementation
@@ -161,17 +161,17 @@ Replace the client-side implementation that returns random stock prices.
 2.  Replace the TODO with the following code. Return prices rather than null.
 
         public StockPrice[] getPrices(String[] symbols) {
-            Random rnd = new Random();
+          Random rnd = new Random();
 
-            StockPrice[] prices = new StockPrice[symbols.length];
-            for (int i=0; i<symbols.length; i++) {
-              double price = rnd.nextDouble() * MAX_PRICE;
-              double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
+          StockPrice[] prices = new StockPrice[symbols.length];
+          for (int i=0; i<symbols.length; i++) {
+            double price = rnd.nextDouble() * MAX_PRICE;
+            double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
 
-              prices[i] = new StockPrice(symbols[i], price, change);
-            }
+            prices[i] = new StockPrice(symbols[i], price, change);
+          }
 
-            return prices;
+          return prices;
         }
 
     Eclipse flags Random and suggests you include the import declaration.
@@ -195,21 +195,21 @@ Replace the client-side implementation that returns random stock prices.
 
         public class StockPriceServiceImpl extends RemoteServiceServlet implements StockPriceService {
 
-            private static final double MAX_PRICE = 100.0; // $100.00
-            private static final double MAX_PRICE_CHANGE = 0.02; // +/- 2%
+          private static final double MAX_PRICE = 100.0; // $100.00
+          private static final double MAX_PRICE_CHANGE = 0.02; // +/- 2%
 
-            public StockPrice[] getPrices(String[] symbols) {
-                Random rnd = new Random();
+          public StockPrice[] getPrices(String[] symbols) {
+            Random rnd = new Random();
 
-                StockPrice[] prices = new StockPrice[symbols.length];
-                for (int i=0; i<symbols.length; i++) {
-                    double price = rnd.nextDouble() * MAX_PRICE;
-                    double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
+            StockPrice[] prices = new StockPrice[symbols.length];
+            for (int i=0; i<symbols.length; i++) {
+              double price = rnd.nextDouble() * MAX_PRICE;
+              double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
 
-                    prices[i] = new StockPrice(symbols[i], price, change);
-                }
+              prices[i] = new StockPrice(symbols[i], price, change);
+            }
 
-                return prices;
+            return prices;
           }
 
         }
@@ -281,7 +281,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 
 public interface StockPriceServiceAsync {
 
-   void getPrices(String[] symbols, AsyncCallback<StockPrice[]> callback);
+  void getPrices(String[] symbols, AsyncCallback<StockPrice[]> callback);
 
 }
 ```
@@ -313,24 +313,24 @@ The AsyncCallback object contains two methods, one of which is called depending 
     Replace the existing refreshWatchList method with the following code.
 
         private void refreshWatchList() {
-            // Initialize the service proxy.
-            if (stockPriceSvc == null) {
-              stockPriceSvc = GWT.create(StockPriceService.class);
+          // Initialize the service proxy.
+          if (stockPriceSvc == null) {
+            stockPriceSvc = GWT.create(StockPriceService.class);
+          }
+
+          // Set up the callback object.
+          AsyncCallback<StockPrice[]> callback = new AsyncCallback<StockPrice[]>() {
+            public void onFailure(Throwable caught) {
+              // TODO: Do something with errors.
             }
 
-             // Set up the callback object.
-            AsyncCallback<StockPrice[]> callback = new AsyncCallback<StockPrice[]>() {
-              public void onFailure(Throwable caught) {
-                // TODO: Do something with errors.
-              }
+            public void onSuccess(StockPrice[] result) {
+              updateTable(result);
+            }
+          };
 
-              public void onSuccess(StockPrice[] result) {
-                updateTable(result);
-              }
-            };
-
-             // Make the call to the stock price service.
-            stockPriceSvc.getPrices(stocks.toArray(new String[0]), callback);
+          // Make the call to the stock price service.
+          stockPriceSvc.getPrices(stocks.toArray(new String[0]), callback);
         }
 
     Eclipse flags AsyncCallback.
@@ -403,7 +403,7 @@ public class StockPrice implements Serializable {
 2.  Add a stock.
 3.  StockWatcher adds the stock to the table; the Price and Change fields contain data and there are no errors.
 
-       *  Atlhough StockWatcher doesn't look any different on the surface, underneath it is now retrieving its stock price updates from the server-side StockPriceService servlet on the embedded servlet container instead of generating them on the client-side.
+       *  Although StockWatcher doesn't look any different on the surface, underneath it is now retrieving its stock price updates from the server-side StockPriceService servlet on the embedded servlet container instead of generating them on the client-side.
 
 At this point, the basic RPC mechanism is working. However, there is one TODO left. You need to code the error handling in case the callback fails.
 
@@ -446,18 +446,18 @@ import java.io.Serializable;
 
 public class DelistedException extends Exception implements Serializable {
 
-    private String symbol;
+  private String symbol;
 
-    public DelistedException() {
-    }
+  public DelistedException() {
+  }
 
-    public DelistedException(String symbol) {
-        this.symbol = symbol;
-    }
+  public DelistedException(String symbol) {
+    this.symbol = symbol;
+  }
 
-    public String getSymbol() {
-        return this.symbol;
-    }
+  public String getSymbol() {
+    return this.symbol;
+  }
 }
 ```
 
@@ -476,7 +476,7 @@ import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 @RemoteServiceRelativePath("stockPrices")
 public interface StockPriceService extends RemoteService {
 
-   StockPrice[] getPrices(String[] symbols) throws DelistedException;
+  StockPrice[] getPrices(String[] symbols) throws DelistedException;
 }
 ```
 
@@ -497,22 +497,22 @@ import com.google.gwt.sample.stockwatcher.client.DelistedException;
 ...
 
 public StockPrice[] getPrices(String[] symbols) throws DelistedException {
-    Random rnd = new Random();
+  Random rnd = new Random();
 
-    StockPrice[] prices = new StockPrice[symbols.length];
+  StockPrice[] prices = new StockPrice[symbols.length];
 
-    for (int i=0; i<symbols.length; i++) {
-        if (symbols[i].equals("ERR")) {
-            throw new DelistedException("ERR");
-        }
-
-        double price = rnd.nextDouble() * MAX_PRICE;
-        double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
-
-        prices[i] = new StockPrice(symbols[i], price, change);
+  for (int i=0; i<symbols.length; i++) {
+    if (symbols[i].equals("ERR")) {
+      throw new DelistedException("ERR");
     }
 
-    return prices;
+    double price = rnd.nextDouble() * MAX_PRICE;
+    double change = price * MAX_PRICE_CHANGE * (rnd.nextDouble() * 2f - 1f);
+
+    prices[i] = new StockPrice(symbols[i], price, change);
+  }
+
+  return prices;
 }
 ```
 
@@ -573,30 +573,30 @@ You will also want to hide the error message if the error is corrected (for exam
     *  In StockWatcher.java, in the refreshWatchList method, fill in the onFailure method as follows.
 
         public void onFailure(Throwable caught) {
-            // If the stock code is in the list of delisted codes, display an error message.
-            String details = caught.getMessage();
-            if (caught instanceof DelistedException) {
-              details = "Company '" + ((DelistedException)caught).getSymbol() + "' was delisted";
-            }
+          // If the stock code is in the list of delisted codes, display an error message.
+          String details = caught.getMessage();
+          if (caught instanceof DelistedException) {
+            details = "Company '" + ((DelistedException) caught).getSymbol() + "' was delisted";
+          }
 
-            errorMsgLabel.setText("Error: " + details);
-            errorMsgLabel.setVisible(true);
+          errorMsgLabel.setText("Error: " + details);
+          errorMsgLabel.setVisible(true);
         }
 
 2.  If the error is corrected, hide the error message widget.
     *  In the updateTable(StockPrice[] prices) method, clear any errors.
 
         private void updateTable(StockPrice[] prices) {
-            for (int i=0; i < prices.length; i++) {
-              updateTable(prices[i]);
-            }
+          for (int i=0; i < prices.length; i++) {
+            updateTable(prices[i]);
+          }
 
-            // Display timestamp showing last refresh.
-            lastUpdatedLabel.setText("Last update : " +
-            DateTimeFormat.getMediumDateTimeFormat().format(new Date()));
+          // Display timestamp showing last refresh.
+          lastUpdatedLabel.setText("Last update : " +
+              DateTimeFormat.getMediumDateTimeFormat().format(new Date()));
 
-            // Clear any errors.
-            errorMsgLabel.setVisible(false);
+          // Clear any errors.
+          errorMsgLabel.setVisible(false);
         }
 
 ### Test Exception Handling in RPC

--- a/src/main/markdown/doc/latest/tutorial/Xsite.md
+++ b/src/main/markdown/doc/latest/tutorial/Xsite.md
@@ -23,7 +23,7 @@ This tutorial builds on the GWT concepts and the StockWatcher application create
 2.  Unzip the file.
 3.  Import the project into Eclipse
 
-        1.  From the `File` menu, select the  `Import...` menu option.
+    1.  From the `File` menu, select the  `Import...` menu option.
     2.  Select the import source General > Existing Projects into Workspace. Click the `Next` button.
     3.  For the root directory, browse to and select the StockWatcher directory (from the unzipped file). Click the `Finish` button.
 
@@ -94,7 +94,6 @@ When the browser finishes downloading the new contents of the `<script>` tag, th
 
 ```
 callback125([{"symbol":"DDD","price":10.610339195026,"change":0.053085447454327}]);
-
 ```
 
 Google Data APIs support this technique.
@@ -130,39 +129,39 @@ If you have access to a web server, then you can use the following PHP script to
 ```
 <?php
 
-      header('Content-Type: text/javascript');
+  header('Content-Type: text/javascript');
   header('Cache-Control: no-cache');
   header('Pragma: no-cache');
 
-      define("MAX_PRICE", 100.0); // $100.00
+  define("MAX_PRICE", 100.0); // $100.00
   define("MAX_PRICE_CHANGE", 0.02); // +/- 2%
 
-      $callback = trim($_GET['callback']);
+  $callback = trim($_GET['callback']);
   echo $callback;
   echo '([';
 
-      $q = trim($_GET['q']);
+  $q = trim($_GET['q']);
   if ($q) {
     $symbols = explode(' ', $q);
 
-        for ($i=0; $i<count($symbols); $i++) {
+    for ($i=0; $i<count($symbols); $i++) {
       $price = lcg_value() * MAX_PRICE;
       $change = $price * MAX_PRICE_CHANGE * (lcg_value() * 2.0 - 1.0);
 
-          echo '{';
+      echo '{';
       echo "\"symbol\":\"$symbols[$i]\",";
       echo "\"price\":$price,";
       echo "\"change\":$change";
       echo '}';
 
-          if ($i < (count($symbols) - 1)) {
+      if ($i < (count($symbols) - 1)) {
         echo ',';
       }
     }
   }
 
-      echo ']);';
-?>`
+  echo ']);';
+?>
 ```
 
 2.  Copy the PHP script to another server.
@@ -174,8 +173,7 @@ If you have access to a web server, then you can use the following PHP script to
 5.  Make a request for the JSONP by appending the name of a callback function.
     *  `http://_[www.myStockServerDomain.com]_/stockPrices.php?q=ABC&callback=callback125`
 6.  The JSON is returned embedded in the callback function.
-    *  `callback125([{"symbol":"ABC","price":53.554212,"change":0.584011}]);
-`
+    *  `callback125([{"symbol":"ABC","price":53.554212,"change":0.584011}]);`
 
 ### Simulating a second server
 
@@ -194,41 +192,41 @@ Also notice that the script supports the callback query string parameter.
 #
 # Copyright 2007 Google Inc. All Rights Reserved.
 
-    import BaseHTTPServer
-    import SimpleHTTPServer
-    import urllib
-    import random
+import BaseHTTPServer
+import SimpleHTTPServer
+import urllib
+import random
 
-    MAX_PRICE = 100.0
-    MAX_PRICE_CHANGE = 0.02
+MAX_PRICE = 100.0
+MAX_PRICE_CHANGE = 0.02
 
-    class MyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+class MyHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
-      def do_GET(self):
+  def do_GET(self):
     form = {}
     if self.path.find('?') > -1:
       queryStr = self.path.split('?')[1]
       form = dict([queryParam.split('=') for queryParam in queryStr.split('&amp;')])
 
-        body = '['
+      body = '['
 
-        if 'q' in form:
-      quotes = []
+      if 'q' in form:
+        quotes = []
 
-          for symbol in urllib.unquote_plus(form['q']).split(' '):
-        price = random.random() * MAX_PRICE
-        change = price * MAX_PRICE_CHANGE * (random.random() * 2.0 - 1.0)
-        quotes.append(('{"symbol":"%s","price":%f,"change":%f}'
+        for symbol in urllib.unquote_plus(form['q']).split(' '):
+          price = random.random() * MAX_PRICE
+          change = price * MAX_PRICE_CHANGE * (random.random() * 2.0 - 1.0)
+          quotes.append(('{"symbol":"%s","price":%f,"change":%f}'
                        % (symbol, price, change)))
 
-          body += ','.join(quotes)
+        body += ','.join(quotes)
 
-        body += ']'
+      body += ']'
 
-        if 'callback' in form:
-      body = ('%s(%s);' % (form['callback'], body))
+      if 'callback' in form:
+        body = ('%s(%s);' % (form['callback'], body))
 
-        self.send_response(200)
+    self.send_response(200)
     self.send_header('Content-Type', 'text/javascript')
     self.send_header('Content-Length', len(body))
     self.send_header('Expires', '-1')
@@ -236,11 +234,11 @@ Also notice that the script supports the callback query string parameter.
     self.send_header('Pragma', 'no-cache')
     self.end_headers()
 
-        self.wfile.write(body)
+    self.wfile.write(body)
     self.wfile.flush()
     self.connection.shutdown(1)
 
-    bhs = BaseHTTPServer.HTTPServer(('', 8000), MyHandler)
+bhs = BaseHTTPServer.HTTPServer(('', 8000), MyHandler)
 bhs.serve_forever()
 ```
 
@@ -258,8 +256,7 @@ bhs.serve_forever()
 7.  Make a request for the JSONP by appending the name of a callback function.
     *  `http://localhost:8000/?q=ABC&callback=callback125`
 8.  The JSON is returned embedded in the callback function.
-    *  `callback125([{"symbol":"ABC","price":53.554212,"change":0.584011}]);
-`
+    *  `callback125([{"symbol":"ABC","price":53.554212,"change":0.584011}]);`
 
 ##  Requesting the data from the remote server <a id="request"></a>
 
@@ -301,28 +298,28 @@ private static final String JSON_URL = "http://_www.myStockServerDomain.com_/sto
     *
 
 ```
-/**
-       * Generate random stock prices.
+  /**
+   * Generate random stock prices.
    */
   private void refreshWatchList() {
     if (stocks.size() == 0) {
       return;
     }
 
-        String url = JSON_URL;
+    String url = JSON_URL;
 
-        // Append watch list stock symbols to query URL.
+    // Append watch list stock symbols to query URL.
     Iterator<String> iter = stocks.iterator();
     while (iter.hasNext()) {
-        url += iter.next();
-        if (iter.hasNext()) {
-            url += "+";
-        }
+      url += iter.next();
+      if (iter.hasNext()) {
+        url += "+";
+      }
     }
 
-        url = URL.encode(url);
+    url = URL.encode(url);
 
-        JsonpRequestBuilder builder = new JsonpRequestBuilder();
+    JsonpRequestBuilder builder = new JsonpRequestBuilder();
     builder.requestObject(url, new AsyncCallback<JsArray<StockData>>() {
       public void onFailure(Throwable caught) {
         displayError("Couldn't retrieve JSON");
@@ -338,16 +335,16 @@ private static final String JSON_URL = "http://_www.myStockServerDomain.com_/sto
     *  The RequestBuilder code is replaced by a call to JsonpRequestBuilder. So you no longer need the following code in the refreshWatchList method:
 
 ```
-// Send request to server and catch any errors.
+    // Send request to server and catch any errors.
     RequestBuilder builder = new RequestBuilder(RequestBuilder.GET, url);
 
-        try {
+    try {
       Request request = builder.sendRequest(null, new RequestCallback() {
         public void onError(Request request, Throwable exception) {
           displayError("Couldn't retrieve JSON");
         }
 
-            public void onResponseReceived(Request request, Response response) {
+        public void onResponseReceived(Request request, Response response) {
           if (200 == response.getStatusCode()) {
             updateTable(JsonUtils.safeEval(response.getText()));
           } else {
@@ -359,7 +356,6 @@ private static final String JSON_URL = "http://_www.myStockServerDomain.com_/sto
     } catch (RequestException e) {
       displayError("Couldn't retrieve JSON");
     }
-
 ```
 
 #### Implement the onSuccess method
@@ -372,12 +368,11 @@ If a response does not come back from the server, you display a message. You can
 
 ```
 if (data == null) {
-      displayError("Couldn't retrieve JSON");
-      return;
-    }
+  displayError("Couldn't retrieve JSON");
+  return;
+}
 
-        updateTable(data);
-
+updateTable(data);
 ```
 
 ##  Testing <a id="test"></a>

--- a/src/main/markdown/doc/latest/tutorial/buildui.md
+++ b/src/main/markdown/doc/latest/tutorial/buildui.md
@@ -439,19 +439,19 @@ public class StockWatcher implements EntryPoint {
     stocksFlexTable.setText(0, 2, "Change");
     stocksFlexTable.setText(0, 3, "Remove");
 
-        // Assemble Add Stock panel.
+    // Assemble Add Stock panel.
     addPanel.add(newSymbolTextBox);
     addPanel.add(addStockButton);
 
-        // Assemble Main panel.
+    // Assemble Main panel.
     mainPanel.add(stocksFlexTable);
     mainPanel.add(addPanel);
     mainPanel.add(lastUpdatedLabel);
 
-        // Associate the Main panel with the HTML host page.
+    // Associate the Main panel with the HTML host page.
     RootPanel.get("stockList").add(mainPanel);
 
-        // Move cursor focus to the input box.
+    // Move cursor focus to the input box.
     newSymbolTextBox.setFocus(true);
 
   }

--- a/src/main/markdown/doc/latest/tutorial/debug.md
+++ b/src/main/markdown/doc/latest/tutorial/debug.md
@@ -32,7 +32,7 @@ Looking at the values in the Price and Change fields, you can see that, for some
 The values for the Change field are loaded by the updateTable(StockPrice) method.
 
 ```
-/**
+  /**
    * Update a single row in the stock table.
    *
    * @param price Stock data for a single row.
@@ -100,8 +100,8 @@ Now step into the code to see where and how the changePercentText is being calcu
 
 ```
 public double getChangePercent() {
-        return 10.0 * this.change / this.price;
-      }
+  return 10.0 * this.change / this.price;
+}
 ```
 
 Looking at the getChangePercent method, you can see the problem: it's multiplying the change percentage by 10 instead of 100. That corresponds exactly with the output you saw before: all of the change percentages were only 1/10 the size of the correct values.
@@ -113,8 +113,8 @@ Looking at the getChangePercent method, you can see the problem: it's multiplyin
 
 ```
 public double getChangePercent() {
-    return 100.0 * this.change / this.price;
-  }
+  return 100.0 * this.change / this.price;
+}
 ```
 
 **Tip:** In Eclipse, if you find it easier to edit in the Java perspective rather than the Debug perspective, you can switch back and forth while running StockWatcher in development mode.

--- a/src/main/markdown/doc/latest/tutorial/i18n.md
+++ b/src/main/markdown/doc/latest/tutorial/i18n.md
@@ -181,18 +181,18 @@ Parameterized messages are not limited to pop-up alerts and error messages. Any 
 ```
 package com.google.gwt.sample.stockwatcher.client;
 
-    import com.google.gwt.i18n.client.Messages;
+import com.google.gwt.i18n.client.Messages;
 
-    import java.util.Date;
+import java.util.Date;
 
-    public interface StockWatcherMessages extends Messages {
+public interface StockWatcherMessages extends Messages {
   @DefaultMessage("''{0}'' is not a valid symbol.")
   String invalidSymbol(String symbol);
 
-      @DefaultMessage("Last update: {0,date,medium} {0,time,medium}")
+  @DefaultMessage("Last update: {0,date,medium} {0,time,medium}")
   String lastUpdate(Date timestamp);
 
-    }
+}
 ```
 
 #### Tips on formatting parameterized messages
@@ -228,7 +228,6 @@ In general, the formatting rules for GWT messages are the same that apply to Jav
 ```
 lastUpdate = Letzte Aktualisierung: {0,date,medium} {0,time,medium}
 invalidSymbol = ''{0}'' ist kein g&uuml;ltiges Aktiensymbol.
-
 ```
 
 ### Replacing hardcoded strings with generated localized ones
@@ -251,9 +250,9 @@ Label widget and calling its setText(String) method. Remember, GWT widgets canno
 ```
 <body>
 
-        <img src="images/GoogleCode.png"/>
+  <img src="images/GoogleCode.png"/>
 
-    <h1 id="appTitle"></h1>
+  <h1 id="appTitle"></h1>
 ```
 
 Now, you should be able to set all of StockWatcher's localized strings at runtime.
@@ -267,8 +266,8 @@ Go through the StockWatcher class and replace all the strings that are hardcoded
 
 ```
 private ArrayList<String> stocks = new ArrayList<String>();
-  private StockWatcherConstants constants = GWT.create(StockWatcherConstants.class);
-  private StockWatcherMessages messages = GWT.create(StockWatcherMessages.class);
+private StockWatcherConstants constants = GWT.create(StockWatcherConstants.class);
+private StockWatcherMessages messages = GWT.create(StockWatcherMessages.class);
 ```
 
 *  Because these are interfaces, not classes, you can't instantiate them directly. Instead, you use the GWT.create(Class) method. Then you'll be able to use these interfaces' accessor methods to retrieve the appropriate strings.
@@ -288,13 +287,13 @@ public void onModuleLoad() {
     RootPanel.get("appTitle").add(new Label(constants.stockWatcher()));
     addStockButton = new Button(constants.add());
 
-        // Create table for stock data.
+    // Create table for stock data.
     stocksFlexTable.setText(0, 0, constants.symbol());
     stocksFlexTable.setText(0, 1, constants.price());
     stocksFlexTable.setText(0, 2, constants.change());
     stocksFlexTable.setText(0, 3, constants.remove());
 
-        ...
+    ...
 ```
 
 4.  Replace the parameterized error message.
@@ -306,14 +305,14 @@ private void addStock() {
     final String symbol = newSymbolTextBox.getText().toUpperCase().trim();
     newSymbolTextBox.setFocus(true);
 
-        // Stock code must be between 1 and 10 chars that are numbers, letters, or dots.
+    // Stock code must be between 1 and 10 chars that are numbers, letters, or dots.
     if (!symbol.matches("^[0-9a-zA-Z\\.]{1,10}$")) {
       Window.alert(messages.invalidSymbol(symbol));
       newSymbolTextBox.selectAll();
       return;
     }
 
-        ...
+    ...
 ```
 
 5.  Move the logic for determining the date format to the Messages interface.
@@ -322,14 +321,14 @@ private void addStock() {
 
 ```
 private void updateTable(StockPrice[] prices) {
-    for (int i = 0; i < prices.length; i++) {
-      updateTable(prices[i]);
-    }
+  for (int i = 0; i < prices.length; i++) {
+    updateTable(prices[i]);
+  }
 
-        // Display timestamp showing last refresh.
-    lastUpdatedLabel.setText(messages.lastUpdate(new Date()));
+  // Display timestamp showing last refresh.
+  lastUpdatedLabel.setText(messages.lastUpdate(new Date()));
 
-      }
+}
 ```
 
 ##  Localizing StockWatcher <a id="local"></a>
@@ -356,9 +355,8 @@ You tell the GWT compiler that StockWatcher now supports the German (de) locale 
     *  Open StockWatcher.gwt.xml and add the following property.
 
 ```
-<entry-point class='com.google.gwt.sample.stockwatcher.client.StockWatcher'/>
-
-      <extend-property name="locale" values="de"/>
+  <entry-point class='com.google.gwt.sample.stockwatcher.client.StockWatcher'/>
+  <extend-property name="locale" values="de"/>
 </module>
 ```
 


### PR DESCRIPTION
Hi GWT team,

Here's a trivial fix for code formatting and spelling errors found in [GWT Tutorials](http://www.gwtproject.org/doc/latest/tutorial/index.html).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/269)
<!-- Reviewable:end -->
