### PR TITLE
Update RunStyle HtmlUnit supported browser emulations

### DIFF
--- a/src/main/markdown/doc/latest/DevGuideTestingHtmlUnit.md
+++ b/src/main/markdown/doc/latest/DevGuideTestingHtmlUnit.md
@@ -25,11 +25,11 @@ times.
 ## RunStyle HtmlUnit
 
 The HtmlUnit runstyle enables you to specify other browser emulations. By
-default, GWT runs HtmlUnit in the Firefox3 emulation mode. As of the 2.0
+default, GWT runs HtmlUnit in the Firefox 38 emulation mode. As of the 2.8
 release, GWT has not been extensively tested on the other emulations that
-HtmlUnit supports, namely FF2, IE6, IE7, and IE8. Still, to use them, you can
+HtmlUnit supports, namely Edge, Chrome, IE8, and IE11. Still, to use them, you can
 define the system property `gwt.args`, as explained before. For example,
-to cause tests to run both in FF3 and IE8 emulation mode, set
+to cause tests to run both in FF38 and IE11 emulation mode, set
 [`gwt.args`](DevGuideTesting.html#passingTestArguments) to:
 
-`-runStyle HtmlUnit:FF3,IE6`
+`-runStyle HtmlUnit:FF38,IE11`


### PR DESCRIPTION
See https://github.com/gwtproject/gwt/blob/2.8.2/user/src/com/google/gwt/junit/RunStyleHtmlUnit.java#L286-L293, https://github.com/gwtproject/gwt/blob/2.8.2/user/src/com/google/gwt/junit/RunStyleHtmlUnit.java#L328-L329, and https://sourceforge.net/p/htmlunit/code/HEAD/tree/tags/HtmlUnit-2.19/src/main/java/com/gargoylesoftware/htmlunit/BrowserVersion.java#l122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/272)
<!-- Reviewable:end -->
