### PR TITLE
Fix broken link to GWT Eclipse Plugin Logo

### DIFF
--- a/src/main/markdown/download.md
+++ b/src/main/markdown/download.md
@@ -59,7 +59,7 @@ Download
   </div>
 </div>
 
-<img class='download-icon' src="http://gwt-plugins.github.io/documentation/gwt-eclipse-plugin/workspace/images/logo.png" />
+<img class='download-icon' src="http://gwt-plugins.github.io/documentation/images/logo.png" />
 <div class='download-block'>
   <h3 style="margin-top: 0em;">
     Plugin for Eclipse <span style="font-weight: normal; font-size: 95%;"> (incl. SDKs)</span>

--- a/src/main/markdown/download.md
+++ b/src/main/markdown/download.md
@@ -17,12 +17,6 @@
   background-color: #9c1421;
   
 }
-.download-icon {
-  max-width: 15% !important;
-  width: 80px;
-  height: auto;
-  float: left;
-}
 .download-block {
   overflow: hidden;
 }
@@ -38,7 +32,6 @@
 Download
 ===
 
-<img class='download-icon' src="images/sdk-sm.png" />
 <div class='download-block'>
   <h3 style="margin-top: 0em;">GWT SDK</h3>
   <p>
@@ -59,7 +52,6 @@ Download
   </div>
 </div>
 
-<img class='download-icon' src="http://gwt-plugins.github.io/documentation/images/logo.png" />
 <div class='download-block'>
   <h3 style="margin-top: 0em;">
     Plugin for Eclipse <span style="font-weight: normal; font-size: 95%;"> (incl. SDKs)</span>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gwtproject/gwt-site/274)
<!-- Reviewable:end -->
