### PR TITLE
Fix creative commons showing on collapsed sidebar

### DIFF
--- a/src/main/site/assets/less/style.less
+++ b/src/main/site/assets/less/style.less
@@ -203,6 +203,7 @@
     margin-top: 20px;
 
     .box-sizing();
+    .transition();
   }
 
   // -> Closed menu
@@ -247,6 +248,10 @@
           margin-left: -123px;
         }
       }
+    }
+
+    #cc {
+      opacity: 0;
     }
   }
 


### PR DESCRIPTION
When the page is >= 960px wide, the left edge of the creative commons attribution text would show on the collapsed sidebar. This PR transitions the CC text to transparent when the menu is closed to fix the issue.