### PR TITLE
Fix creative commons showing on collapsed sidebar

### DIFF
--- a/src/main/site/assets/less/style.less
+++ b/src/main/site/assets/less/style.less
@@ -199,7 +199,7 @@
 
     display: block;
     width: 100%;
-    padding: 10px 35px;
+    padding: 10px 40px;
     margin-top: 20px;
 
     .box-sizing();


### PR DESCRIPTION
Updated fixes based off the discussion in #290 

Fixes a small portion of the Creative Commons text overflowing the sidebar on displays >= 960px wide.