### PR TITLE
Reintroduce jetty plugin for running and testing the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ If you don't have Grunt installer :
 ### Running locally
 Run the site locally for easy visual testing
 
+Run without server:
 * Change to the `target/generated-site` folder.
 * Open the `index.html` file in your browser.
-* Additionally, you could run any local HTTP server in this folder.
+
+Run with Maven:
+* Run: `mvn jetty:run`
+* Open URL `http://localhost:9999` in your browser.

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,17 @@
           </descriptors>
         </configuration>
       </plugin>
+      <plugin>      
+        <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-maven-plugin</artifactId>
+          <version>9.4.5.v20170502</version>     
+          <configuration>
+            <httpConnector>
+              <port>9999</port>
+            </httpConnector>
+            <webAppSourceDirectory>${project.build.directory}/generated-site</webAppSourceDirectory>      
+          </configuration>        
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,16 +105,19 @@
           </descriptors>
         </configuration>
       </plugin>
-      <plugin>      
+      <plugin>
         <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
-          <version>9.4.5.v20170502</version>     
+          <version>9.4.28.v20200408</version>
           <configuration>
             <httpConnector>
               <port>9999</port>
             </httpConnector>
-            <webAppSourceDirectory>${project.build.directory}/generated-site</webAppSourceDirectory>      
-          </configuration>        
+            <supportedPackagings>
+              <supportedPackaging>jar</supportedPackaging>
+            </supportedPackagings>
+            <webAppSourceDirectory>${project.build.directory}/generated-site</webAppSourceDirectory>
+          </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Using the Jetty plugin facilitates running the site and testing of local changes. This makes contributing easier.