### PR TITLE
Update deps to fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>1.3</version>
+            <version>1.9.1</version>
             <executions>
               <execution>
                 <id>install node and npm</id>
@@ -147,8 +147,8 @@
                   <goal>install-node-and-npm</goal>
                 </goals>
                 <configuration>
-                  <nodeVersion>v7.6.0</nodeVersion>
-                  <npmVersion>4.3.0</npmVersion>
+                  <nodeVersion>v10.16.0</nodeVersion>
+                  <npmVersion>6.9.0</npmVersion>
                 </configuration>
               </execution>
               <execution>


### PR DESCRIPTION
Seems that Grunt doesn't work anymore with the old node and npm versions. This PR fixes that issue by updating deps:

- update frontend-maven-plugin
- update node and npm version