### PR TITLE
Fix additional stale reference to Google usage

### DIFF
--- a/src/main/site/index.html
+++ b/src/main/site/index.html
@@ -113,9 +113,7 @@
 
                         <div class="col col-2_3">
 
-                            <p>GWT is used by many products at Google, including Google AdWords
-                                and Google Wallet.
-                                It's open source, completely free, and used by thousands of
+                            <p>GWT is open source, completely free, and used by thousands of
                                 enthusiastic developers
                                 around the world.</p>
 


### PR DESCRIPTION
Follow up to https://github.com/gwtproject/gwt-site/commit/5a32e0b7e6d219b82003ec6a6240dffca6e9ee1c.

GWT is no longer used by AdWords.