### PR TITLE
Replace Google+ community links with links to Gitter community

### DIFF
--- a/src/main/markdown/community.md
+++ b/src/main/markdown/community.md
@@ -34,7 +34,7 @@ Before submitting your post, please try the following:
 
 ## Other communities
 
-There is a [GWT community over at Google+](https://plus.google.com/u/0/communities/116543000751323604177). There's also the IRC channel #gwt on the Freenode network.
+There is a [GWT Gitter Community](https://gitter.im/gwtproject/gwt). There's also the IRC channel #gwt on the Freenode network.
 
 ## Contribute
 

--- a/src/main/markdown/doc/latest/FAQ.md
+++ b/src/main/markdown/doc/latest/FAQ.md
@@ -2,7 +2,7 @@ FAQ
 ===
 
 This section includes often-asked and answered questions about GWT, organized by category. 
-If you can't find the answer to your question here, try searching in the [GWT Developer Forum](http://groups.google.com/group/Google-Web-Toolkit) or visit the [Google Plus Community](https://plus.google.com/communities/116543000751323604177). 
+If you can't find the answer to your question here, try searching in the [GWT Developer Forum](http://groups.google.com/group/Google-Web-Toolkit) or visit the [GWT Gitter Community](https://gitter.im/gwtproject/gwt). 
 If you still can't find the answer, don't be shy: join the group and post your question.
 People on the group are friendly and often surprisingly helpful.
 

--- a/src/main/resources/main.tpl
+++ b/src/main/resources/main.tpl
@@ -67,8 +67,8 @@
                     <li class="btn"><a href="http://www.gwtproject.org/javadoc/latest/"><i class="icon_jd"></i>Java Doc</a></li>
                 </ul>
                 <div id="social">
-                    <a class="googleplus" href="https://plus.google.com/communities/116543000751323604177" target="_blank">
-                        <i class="icon_google"></i><span>Access our Google+ community</span>
+                    <a href="https://gitter.im/gwtproject/gwt" target="_blank" title="Access our Gitter community">
+                        <img src="images/gitter-logo.svg" height="100%" alt="GWT Gitter community"></img>
                     </a>
                 </div>
                 <a id="cc" href="#">Creative Commons Attribution 3.0 License.</a>

--- a/src/main/site/images/gitter-logo.svg
+++ b/src/main/site/images/gitter-logo.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 17 25">
+    <defs>
+    <style type="text/css"><![CDATA[
+       .red {
+         stroke: #f93535;
+         fill: #f93535;
+       }
+    ]]></style>
+    </defs>
+    <rect class="red" x="15" y="5" width="2" height="10"></rect>
+    <rect class="red" x="10" y="5" width="2" height="20"></rect>
+    <rect class="red" x="5" y="5" width="2" height="20"></rect>
+    <rect class="red" x="0" y="0" width="2" height="15"></rect>
+</svg>

--- a/src/main/site/index.html
+++ b/src/main/site/index.html
@@ -70,8 +70,8 @@
                     <li class="btn"><a href="http://www.gwtproject.org/javadoc/latest/"><i class="icon_jd"></i>Java Doc</a></li>
                 </ul>
                 <div id="social">
-                    <a class="googleplus" href="https://plus.google.com/communities/116543000751323604177" target="_blank">
-                        <i class="icon_google"></i><span>Access our Google+ community</span>
+                    <a href="https://gitter.im/gwtproject/gwt" target="_blank" title="Access our Gitter community">
+                        <img src="images/gitter-logo.svg" height="100%" alt="GWT Gitter community"></img>
                     </a>
                 </div>
                 <a id="cc" href="#">Creative Commons Attribution 3.0 License.</a>


### PR DESCRIPTION
This pull request replaces several stale G+ links with links to the very active Gitter community ( resolves #288 ).

![image](https://user-images.githubusercontent.com/1841306/82668778-7ef14a00-9c3a-11ea-95af-f405076237d0.png)
