### PR TITLE
Remove Christian Goudreau from SC members list.

### DIFF
--- a/src/main/markdown/steering.md
+++ b/src/main/markdown/steering.md
@@ -16,7 +16,6 @@ The steering committee consists of the following members (no particular order):
 * Thomas Broyer
 * Stephen Haberman, [LinkedIn](https://www.linkedin.com/about-us)
 * Julien Dramaix, [Google](https://www.google.com/about/)
-* Christian Goudreau, [Arcbees](https://www.arcbees.com)
 * Konstantin Solomatov, [Jetbrains](https://www.jetbrains.com)
 * Frank Hossfeld [Hossfeld Solutions GmbH](https://www.hossfeld-solutions.de/)
 


### PR DESCRIPTION
as per https://groups.google.com/d/msgid/gwt-steering/CAN4j5mtaztSu1ANOZpsEVW%3DMYndR-bo6dAB5sLWML7rC1_QWng%40mail.gmail.com