### PR TITLE
Update command line options for Compiler, DevMode and SuperDevMode

### DIFF
--- a/src/main/markdown/articles/superdevmode.md
+++ b/src/main/markdown/articles/superdevmode.md
@@ -1,7 +1,7 @@
 Super Dev Mode
 ===
 
-*Revised December 17, 2015 for GWT 2.8*
+*Revised June 19, 2020 for GWT 2.9*
 
 ## Introduction <a id="Introduction"></a>
 
@@ -71,31 +71,34 @@ needed to compile your GWT app (most likely gwt-user.jar).
 * The main method is in com.google.gwt.dev.codeserver.CodeServer
 
 If you run CodeServer without any arguments, it will print out its
-command line arguments. For 2.8.0-beta1, here is the output:
+command line arguments. For 2.9.0, here is the output:
+```
+Google Web Toolkit 2.9.0
+CodeServer [-[no]allowMissingSrc] [-[no]compileTest] [-compileTestRecompiles count] [-[no]failOnError] [-[no]precompile] [-port port] [-src dir] [-workDir dir] [-launcherDir] [-bindAddress host-name-or-address] [-style (DETAILED|OBFUSCATED|PRETTY)] [-setProperty name=value,value...] [-[no]incremental] [-sourceLevel [auto, 1.8, 1.9, 1.10, 1.11]] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-[no]generateJsInteropExports] [-includeJsInteropExports/excludeJsInteropExports regex] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-X[no]closureFormattedOutput] [module]
 
-    CodeServer [-[no]allowMissingSrc] [-bindAddress address] [-[no]compileTest] [-compileTestRecompiles count] [-[no]failOnError] [-[no]precompile] [-port port] [-src dir] [-workDir dir] [-launcherDir] [-style (DETAILED|OBFUSCATED|PRETTY)] [-setProperty name=value,value...] [-[no]incremental] [-sourceLevel [auto, 1.7, 1.8]] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-XjsInteropMode (JS|JS_RC)] [-[no]generateJsInteropExports] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-X[no]closureFormattedOutput] [module]
-
-    where
-      -[no]allowMissingSrc          Allows -src flags to reference missing directories. (defaults to OFF)
-      -bindAddress                  The ip address of the code server. Defaults to 127.0.0.1.
-      -[no]compileTest              Exits after compiling the modules. The exit code will be 0 if the compile succeeded. (defaults to OFF)
-      -compileTestRecompiles        The number of times to recompile (after the first one) during a compile test.
-      -[no]failOnError              Stop compiling if a module has a Java file with a compile error, even if unused. (defaults to OFF)
-      -[no]precompile               Precompile modules. (defaults to ON)
-      -port                         The port where the code server will run.
-      -src                          A directory containing GWT source to be prepended to the classpath for compiling.
-      -workDir                      The root of the directory tree where the code server willwrite compiler output. If not supplied, a temporary directorywill be used.
-      -launcherDir                  An output directory where files for launching Super Dev Mode will be written. (Optional.)
-      -style                        Script output style: DETAILED, OBFUSCATED or PRETTY
-      -setProperty                  Set the values of a property in the form of propertyName=value1[,value2...].
-      -[no]incremental              Compiles faster by reusing data from the previous compile. (defaults to ON)
-      -sourceLevel                  Specifies Java source level (defaults to auto:1.8)
-      -logLevel                     The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)
-      -XjsInteropMode               EXPERIMENTAL: DEPRECATED: Specifies JsInterop mode: JS or JS_RC
-      -[no]generateJsInteropExports Generate exports for JsInterop purposes (defaults to OFF)
-      -XmethodNameDisplayMode       EXPERIMENTAL: Specifies method display name mode for chrome devtools: NONE, ONLY_METHOD_NAME, ABBREVIATED or FULL (defaults to NONE)
-    and
-      module                        The GWT modules that the code server should compile. (Example: com.example.MyApp)
+where
+  -[no]allowMissingSrc                              Allows -src flags to reference missing directories. (defaults to OFF)
+  -[no]compileTest                                  Exits after compiling the modules. The exit code will be 0 if the compile succeeded. (defaults to OFF)
+  -compileTestRecompiles                            The number of times to recompile (after the first one) during a compile test.
+  -[no]failOnError                                  Stop compiling if a module has a Java file with a compile error, even if unused. (defaults to OFF)
+  -[no]precompile                                   Precompile modules. (defaults to ON)
+  -port                                             The port where the code server will run.
+  -src                                              A directory containing GWT source to be prepended to the classpath for compiling.
+  -workDir                                          The root of the directory tree where the code server willwrite compiler output. If not supplied, a temporary directorywill be used.
+  -launcherDir                                      An output directory where files for launching Super Dev Mode will be written. (Optional.)
+  -bindAddress                                      Specifies the bind address for the code server and web server (defaults to 127.0.0.1)
+  -style                                            Script output style: DETAILED, OBFUSCATED or PRETTY
+  -setProperty                                      Set the values of a property in the form of propertyName=value1[,value2...].
+  -[no]incremental                                  Compiles faster by reusing data from the previous compile. (defaults to ON)
+  -sourceLevel                                      Specifies Java source level (defaults to 1.8)
+  -logLevel                                         The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)
+  -[no]generateJsInteropExports                     Generate exports for JsInterop purposes. If no -includeJsInteropExport/-excludeJsInteropExport provided, generates all exports. (defaults to OFF)
+  -includeJsInteropExports/excludeJsInteropExports  Include/exclude members and classes while generating JsInterop exports. Flag could be set multiple times to expand the pattern. (The flag has only effect if exporting is enabled via -generateJsInteropExports)
+  -XmethodNameDisplayMode                           EXPERIMENTAL: Specifies method display name mode for chrome devtools: NONE, ONLY_METHOD_NAME, ABBREVIATED or FULL (defaults to NONE)
+  -X[no]closureFormattedOutput                      EXPERIMENTAL: Enables Javascript output suitable for post-compilation by Closure Compiler (defaults to OFF)
+and
+  module                                            The GWT modules that the code server should compile. (Example: com.example.MyApp)
+```
 
 At a minimum, you need to give it the name of the GWT module to compile.
 

--- a/src/main/markdown/doc/latest/DevGuideCompilingAndDebugging.md
+++ b/src/main/markdown/doc/latest/DevGuideCompilingAndDebugging.md
@@ -314,34 +314,35 @@ There are many options you can pass to the development mode process to control h
 ```
 $ java -cp gwt-dev.jar com.google.gwt.dev.DevMode
 Missing required argument 'module[s]'
-Google Web Toolkit 2.8.0
-DevMode [-[no]startServer] [-port port-number | "auto"] [-logdir directory] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-gen dir] [-bindAddress host-name-or-address] [-codeServerPort port-number | "auto"] [-[no]superDevMode] [-server servletContainerLauncher[:args]] [-startupUrl url] [-war dir] [-deploy dir] [-extra dir] [-modulePathPrefix ] [-workDir dir] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-sourceLevel [1.8|1.9|1.10|1.11]] [-[no]generateJsInteropExports] [-[no]incremental] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-setProperty name=value,value...] module[s]
+Google Web Toolkit 2.9.0
+DevMode [-[no]startServer] [-port port-number | "auto"] [-logdir directory] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-gen dir] [-bindAddress host-name-or-address] [-codeServerPort port-number | "auto"] [-[no]superDevMode] [-server servletContainerLauncher[:args]] [-startupUrl url] [-war dir] [-deploy dir] [-extra dir] [-modulePathPrefix ] [-workDir dir] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-sourceLevel [auto, 1.8, 1.9, 1.10, 1.11]] [-[no]generateJsInteropExports] [-includeJsInteropExports/excludeJsInteropExports regex] [-[no]incremental] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-setProperty name=value,value...] module[s]
 
 where
-  -[no]startServer               Starts a servlet container serving the directory specified by the -war flag. (defaults to ON)
-  -port                          Specifies the TCP port for the embedded web server (defaults to 8888)
-  -logdir                        Logs to a file in the given directory, as wellas graphically
-  -logLevel                      The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)
-  -gen                           Debugging: causes normally-transient generated types to be saved in the specified directory
-  -bindAddress                   Specifies the bind address for the code server and web server (defaults to 127.0.0.1)
-  -codeServerPort                Specifies the TCP port for the code server (defaults to 9997 for classic Dev Mode or 9876 for Super Dev Mode)
-  -[no]superDevMode              Runs Super Dev Mode instead of classic Development Mode. (defaults to ON)
-  -server                        Specify a different embedded web server to run (must implement ServletContainerLauncher)
-  -startupUrl                    Automatically launches the specified URL
-  -war                           The directory into which deployable output files will be written (defaults to 'war')
-  -deploy                        The directory into which deployable but not servable output files will be written (defaults to 'WEB-INF/deploy' under the -war directory/jar, and may be the same as the -extra directory/jar)
-  -extra                         The directory into which extra files, not intended for deployment, will be written
-  -modulePathPrefix              The subdirectory inside the war dir where DevMode will create module directories. (defaults empty for top level)
-  -workDir                       The compiler's working directory for internal use (must be writeable; defaults to a system temp dir)
-  -XmethodNameDisplayMode        EXPERIMENTAL: Specifies method display name mode for chrome devtools: NONE, ONLY_METHOD_NAME, ABBREVIATED or FULL (defaults to NONE)
-  -sourceLevel                   Specifies Java source level (defaults to 1.8)
-  -[no]generateJsInteropExports  Generate exports for JsInterop purposes (defaults to OFF)
-  -[no]incremental               Compiles faster by reusing data from the previous compile. (defaults to ON)
-  -style                         Script output style: DETAILED, OBFUSCATED or PRETTY (defaults to OBFUSCATED)
-  -[no]failOnError               Fail compilation if any input file contains anerror. (defaults to OFF)
-  -setProperty                   Set the values of a property in the form of propertyName=value1[,value2...].
+  -[no]startServer                                  Starts a servlet container serving the directory specified by the -war flag. (defaults to ON)
+  -port                                             Specifies the TCP port for the embedded web server (defaults to 8888)
+  -logdir                                           Logs to a file in the given directory, as well as graphically
+  -logLevel                                         The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)
+  -gen                                              Debugging: causes normally-transient generated types to be saved in the specified directory
+  -bindAddress                                      Specifies the bind address for the code server and web server (defaults to 127.0.0.1)
+  -codeServerPort                                   Specifies the TCP port for the code server (defaults to 9997 for classic Dev Mode or 9876 for Super Dev Mode)
+  -[no]superDevMode                                 Runs Super Dev Mode instead of classic Development Mode. (defaults to ON)
+  -server                                           Specify a different embedded web server to run (must implement ServletContainerLauncher)
+  -startupUrl                                       Automatically launches the specified URL
+  -war                                              The directory into which deployable output files will be written (defaults to 'war')
+  -deploy                                           The directory into which deployable but not servable output files will be written (defaults to 'WEB-INF/deploy' under the -war directory/jar, and may be the same as the -extra directory/jar)
+  -extra                                            The directory into which extra files, not intended for deployment, will be written
+  -modulePathPrefix                                 The subdirectory inside the war dir where DevMode will create module directories. (defaults empty for top level)
+  -workDir                                          The compiler's working directory for internal use (must be writeable; defaults to a system temp dir)
+  -XmethodNameDisplayMode                           EXPERIMENTAL: Specifies method display name mode for chrome devtools: NONE, ONLY_METHOD_NAME, ABBREVIATED or FULL (defaults to NONE)
+  -sourceLevel                                      Specifies Java source level (defaults to 1.8)
+  -[no]generateJsInteropExports                     Generate exports for JsInterop purposes. If no -includeJsInteropExport/-excludeJsInteropExport provided, generates all exports. (defaults to OFF)
+  -includeJsInteropExports/excludeJsInteropExports  Include/exclude members and classes while generating JsInterop exports. Flag could be set multiple times to expand the pattern. (The flag has only effect if exporting is enabled via -generateJsInteropExports)
+  -[no]incremental                                  Compiles faster by reusing data from the previous compile. (defaults to ON)
+  -style                                            Script output style: DETAILED, OBFUSCATED or PRETTY (defaults to OBFUSCATED)
+  -[no]failOnError                                  Fail compilation if any input file contains an error. (defaults to OFF)
+  -setProperty                                      Set the values of a property in the form of propertyName=value1[,value2...].
 and
-  module[s]                      Specifies the name(s) of the module(s) to host
+  module[s]                                         Specifies the name(s) of the module(s) to host
 ```
 
 Any time you want to look up the development mode options available for your version of GWT, you can simply invoke the DevMode class from command-line as shown above and it will list out the options available along with their descriptions.  (Run the command from the directory containing `gwt-dev.jar` or add the path ahead of that file: `-cp _path_/gwt-dev.jar`.)
@@ -541,39 +542,40 @@ There are many options you can pass to the GWT compiler process to control how y
 ```
 > java -cp gwt-dev.jar com.google.gwt.dev.Compiler
 Missing required argument 'module[s]'
-Google Web Toolkit 2.8.0
-Compiler [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-workDir dir] [-X[no]closureFormattedOutput] [-[no]compileReport] [-X[no]checkCasts] [-X[no]classMetadata] [-[no]draftCompile] [-[no]checkAssertions] [-XfragmentCount numFragments] [-XfragmentMerge numFragments] [-gen dir] [-[no]generateJsInteropExports] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-Xnamespace (NONE|PACKAGE)] [-optimize level] [-[no]saveSource] [-setProperty name=value,value...] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-[no]validateOnly] [-sourceLevel [1.8|1.9|1.10|1.11]] [-localWorkers count] [-[no]incremental] [-war dir] [-deploy dir] [-extra dir] [-saveSourceOutput dir] module[s]
+Google Web Toolkit 2.9.0
+Compiler [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-workDir dir] [-X[no]closureFormattedOutput] [-[no]compileReport] [-X[no]checkCasts] [-X[no]classMetadata] [-[no]draftCompile] [-[no]checkAssertions] [-XfragmentCount numFragments] [-XfragmentMerge numFragments] [-gen dir] [-[no]generateJsInteropExports] [-includeJsInteropExports/excludeJsInteropExports regex] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-Xnamespace (NONE|PACKAGE)] [-optimize level] [-[no]saveSource] [-setProperty name=value,value...] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-[no]validateOnly] [-sourceLevel [auto, 1.8, 1.9, 1.10, 1.11]] [-localWorkers count] [-[no]incremental] [-war dir] [-deploy dir] [-extra dir] [-saveSourceOutput dir] module[s]
 
 where
-  -logLevel                      The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)
-  -workDir                       The compiler's working directory for internal use (must be writeable; defaults to a system temp dir)
-  -X[no]closureFormattedOutput   EXPERIMENTAL: Enables Javascript output suitable for post-compilation by Closure Compiler (defaults to OFF)
-  -[no]compileReport             Compile a report that tells the "Story of Your Compile". (defaults to OFF)
-  -X[no]checkCasts               EXPERIMENTAL: DEPRECATED: use jre.checks.checkLevel instead. (defaults to OFF)
-  -X[no]classMetadata            EXPERIMENTAL: Include metadata for some java.lang.Class methods (e.g. getName()). (defaults to ON)
-  -[no]draftCompile              Compile quickly with minimal optimizations. (defaults to OFF)
-  -[no]checkAssertions           Include assert statements in compiled output. (defaults to OFF)
-  -XfragmentCount                EXPERIMENTAL: Limits of number of fragments using a code splitter that merges split points.
-  -XfragmentMerge                DEPRECATED (use -XfragmentCount instead): Enables Fragment merging code splitter.
-  -gen                           Debugging: causes normally-transient generated types to be saved in the specified directory
-  -[no]generateJsInteropExports  Generate exports for JsInterop purposes (defaults to OFF)
-  -XmethodNameDisplayMode        EXPERIMENTAL: Specifies method display name mode for chrome devtools: NONE, ONLY_METHOD_NAME, ABBREVIATED or FULL (defaults to NONE)
-  -Xnamespace                    Puts most JavaScript globals into namespaces. Default: PACKAGE for -draftCompile, otherwise NONE
-  -optimize                      Sets the optimization level used by the compiler.  0=none 9=maximum.
-  -[no]saveSource                Enables saving source code needed by debuggers. Also see -debugDir. (defaults to OFF)
-  -setProperty                   Set the values of a property in the form of propertyName=value1[,value2...].
-  -style                         Script output style: DETAILED, OBFUSCATED or PRETTY (defaults to OBFUSCATED)
-  -[no]failOnError               Fail compilation if any input file contains an error. (defaults to OFF)
-  -[no]validateOnly              Validate all source code, but do not compile. (defaults to OFF)
-  -sourceLevel                   Specifies Java source level (defaults to 1.8)
-  -localWorkers                  The number of local workers to use when compiling permutations
-  -[no]incremental               Compiles faster by reusing data from the previous compile. (defaults to OFF)
-  -war                           The directory into which deployable output files will be written (defaults to 'war')
-  -deploy                        The directory into which deployable but not servable output files will be written (defaults to 'WEB-INF/deploy' under the -war directory/jar, and may be the same as the -extra directory/jar)
-  -extra                         The directory into which extra files, not intended for deployment, will be written
-  -saveSourceOutput              Overrides where source files useful to debuggers will be written. Default: saved with extras.
+  -logLevel                                         The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)
+  -workDir                                          The compiler's working directory for internal use (must be writeable; defaults to a system temp dir)
+  -X[no]closureFormattedOutput                      EXPERIMENTAL: Enables Javascript output suitable for post-compilation by Closure Compiler (defaults to OFF)
+  -[no]compileReport                                Compile a report that tells the "Story of Your Compile". (defaults to OFF)
+  -X[no]checkCasts                                  EXPERIMENTAL: DEPRECATED: use jre.checks.checkLevel instead. (defaults to OFF)
+  -X[no]classMetadata                               EXPERIMENTAL: Include metadata for some java.lang.Class methods (e.g. getName()). (defaults to ON)
+  -[no]draftCompile                                 Compile quickly with minimal optimizations. (defaults to OFF)
+  -[no]checkAssertions                              Include assert statements in compiled output. (defaults to OFF)
+  -XfragmentCount                                   EXPERIMENTAL: Limits of number of fragments using a code splitter that merges split points.
+  -XfragmentMerge                                   DEPRECATED (use -XfragmentCount instead): Enables Fragment merging code splitter.
+  -gen                                              Debugging: causes normally-transient generated types to be saved in the specified directory
+  -[no]generateJsInteropExports                     Generate exports for JsInterop purposes. If no -includeJsInteropExport/-excludeJsInteropExport provided, generates all exports. (defaults to OFF)
+  -includeJsInteropExports/excludeJsInteropExports  Include/exclude members and classes while generating JsInterop exports. Flag could be set multiple times to expand the pattern. (The flag has only effect if exporting is enabled via -generateJsInteropExports)
+  -XmethodNameDisplayMode                           EXPERIMENTAL: Specifies method display name mode for chrome devtools: NONE, ONLY_METHOD_NAME, ABBREVIATED or FULL (defaults to NONE)
+  -Xnamespace                                       Puts most JavaScript globals into namespaces. Default: PACKAGE for -draftCompile, otherwise NONE
+  -optimize                                         Sets the optimization level used by the compiler.  0=none 9=maximum.
+  -[no]saveSource                                   Enables saving source code needed by debuggers. Also see -debugDir. (defaults to OFF)
+  -setProperty                                      Set the values of a property in the form of propertyName=value1[,value2...].
+  -style                                            Script output style: DETAILED, OBFUSCATED or PRETTY (defaults to OBFUSCATED)
+  -[no]failOnError                                  Fail compilation if any input file contains an error. (defaults to OFF)
+  -[no]validateOnly                                 Validate all source code, but do not compile. (defaults to OFF)
+  -sourceLevel                                      Specifies Java source level (defaults to 1.8)
+  -localWorkers                                     The number of local workers to use when compiling permutations
+  -[no]incremental                                  Compiles faster by reusing data from the previous compile. (defaults to OFF)
+  -war                                              The directory into which deployable output files will be written (defaults to 'war')
+  -deploy                                           The directory into which deployable but not servable output files will be written (defaults to 'WEB-INF/deploy' under the -war directory/jar, and may be the same as the -extra directory/jar)
+  -extra                                            The directory into which extra files, not intended for deployment, will be written
+  -saveSourceOutput                                 Overrides where source files useful to debuggers will be written. Default: saved with extras.
 and
-  module[s]                      Specifies the name(s) of the module(s) to compile
+  module[s]                                         Specifies the name(s) of the module(s) to compile
 ```
 
 Any time you want to look up GWT compiler options available for your version of GWT, you can simply invoke the Compiler class from command-line as shown above and it will list out the options available along with their descriptions.  (Run the command from the directory containing `gwt-dev.jar` or add the path ahead of that file: `-cp _path_/gwt-dev.jar`.)

--- a/src/main/markdown/doc/latest/DevGuideCompilingAndDebugging.md
+++ b/src/main/markdown/doc/latest/DevGuideCompilingAndDebugging.md
@@ -315,7 +315,7 @@ There are many options you can pass to the development mode process to control h
 $ java -cp gwt-dev.jar com.google.gwt.dev.DevMode
 Missing required argument 'module[s]'
 Google Web Toolkit 2.8.0
-DevMode [-[no]startServer] [-port port-number | "auto"] [-logdir directory] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-gen dir] [-bindAddress host-name-or-address] [-codeServerPort port-number | "auto"] [-[no]superDevMode] [-server servletContainerLauncher[:args]] [-startupUrl url] [-war dir] [-deploy dir] [-extra dir] [-modulePathPrefix ] [-workDir dir] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-sourceLevel [auto, 1.8]] [-[no]generateJsInteropExports] [-[no]incremental] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-setProperty name=value,value...] module[s]
+DevMode [-[no]startServer] [-port port-number | "auto"] [-logdir directory] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-gen dir] [-bindAddress host-name-or-address] [-codeServerPort port-number | "auto"] [-[no]superDevMode] [-server servletContainerLauncher[:args]] [-startupUrl url] [-war dir] [-deploy dir] [-extra dir] [-modulePathPrefix ] [-workDir dir] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-sourceLevel [1.8|1.9|1.10|1.11]] [-[no]generateJsInteropExports] [-[no]incremental] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-setProperty name=value,value...] module[s]
 
 where
   -[no]startServer               Starts a servlet container serving the directory specified by the -war flag. (defaults to ON)
@@ -542,7 +542,7 @@ There are many options you can pass to the GWT compiler process to control how y
 > java -cp gwt-dev.jar com.google.gwt.dev.Compiler
 Missing required argument 'module[s]'
 Google Web Toolkit 2.8.0
-Compiler [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-workDir dir] [-X[no]closureFormattedOutput] [-[no]compileReport] [-X[no]checkCasts] [-X[no]classMetadata] [-[no]draftCompile] [-[no]checkAssertions] [-XfragmentCount numFragments] [-XfragmentMerge numFragments] [-gen dir] [-[no]generateJsInteropExports] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-Xnamespace (NONE|PACKAGE)] [-optimize level] [-[no]saveSource] [-setProperty name=value,value...] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-[no]validateOnly] [-sourceLevel [auto, 1.8]] [-localWorkers count] [-[no]incremental] [-war dir] [-deploy dir] [-extra dir] [-saveSourceOutput dir] module[s]
+Compiler [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-workDir dir] [-X[no]closureFormattedOutput] [-[no]compileReport] [-X[no]checkCasts] [-X[no]classMetadata] [-[no]draftCompile] [-[no]checkAssertions] [-XfragmentCount numFragments] [-XfragmentMerge numFragments] [-gen dir] [-[no]generateJsInteropExports] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-Xnamespace (NONE|PACKAGE)] [-optimize level] [-[no]saveSource] [-setProperty name=value,value...] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-[no]validateOnly] [-sourceLevel [1.8|1.9|1.10|1.11]] [-localWorkers count] [-[no]incremental] [-war dir] [-deploy dir] [-extra dir] [-saveSourceOutput dir] module[s]
 
 where
   -logLevel                      The level of logging detail: ERROR, WARN, INFO, TRACE, DEBUG, SPAM or ALL (defaults to INFO)


### PR DESCRIPTION
Mention more recent Java versions supported by the GWT compiler.

Found the values here: https://github.com/gwtproject/gwt/blob/master/dev/core/src/com/google/gwt/dev/util/arg/SourceLevel.java