### PR TITLE
Update site (except generated docs) for GWT 2.10.0 release

### DIFF
--- a/src/main/markdown/articles/superdevmode.md
+++ b/src/main/markdown/articles/superdevmode.md
@@ -71,9 +71,9 @@ needed to compile your GWT app (most likely gwt-user.jar).
 * The main method is in com.google.gwt.dev.codeserver.CodeServer
 
 If you run CodeServer without any arguments, it will print out its
-command line arguments. For 2.9.0, here is the output:
+command line arguments. For 2.10.0, here is the output:
 ```
-Google Web Toolkit 2.9.0
+Google Web Toolkit 2.10.0
 CodeServer [-[no]allowMissingSrc] [-[no]compileTest] [-compileTestRecompiles count] [-[no]failOnError] [-[no]precompile] [-port port] [-src dir] [-workDir dir] [-launcherDir] [-bindAddress host-name-or-address] [-style (DETAILED|OBFUSCATED|PRETTY)] [-setProperty name=value,value...] [-[no]incremental] [-sourceLevel [auto, 1.8, 1.9, 1.10, 1.11]] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-[no]generateJsInteropExports] [-includeJsInteropExports/excludeJsInteropExports regex] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-X[no]closureFormattedOutput] [module]
 
 where

--- a/src/main/markdown/doc/latest/DevGuideCompilingAndDebugging.md
+++ b/src/main/markdown/doc/latest/DevGuideCompilingAndDebugging.md
@@ -314,7 +314,7 @@ There are many options you can pass to the development mode process to control h
 ```
 $ java -cp gwt-dev.jar com.google.gwt.dev.DevMode
 Missing required argument 'module[s]'
-Google Web Toolkit 2.9.0
+Google Web Toolkit 2.10.0
 DevMode [-[no]startServer] [-port port-number | "auto"] [-logdir directory] [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-gen dir] [-bindAddress host-name-or-address] [-codeServerPort port-number | "auto"] [-[no]superDevMode] [-server servletContainerLauncher[:args]] [-startupUrl url] [-war dir] [-deploy dir] [-extra dir] [-modulePathPrefix ] [-workDir dir] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-sourceLevel [auto, 1.8, 1.9, 1.10, 1.11]] [-[no]generateJsInteropExports] [-includeJsInteropExports/excludeJsInteropExports regex] [-[no]incremental] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-setProperty name=value,value...] module[s]
 
 where
@@ -542,7 +542,7 @@ There are many options you can pass to the GWT compiler process to control how y
 ```
 > java -cp gwt-dev.jar com.google.gwt.dev.Compiler
 Missing required argument 'module[s]'
-Google Web Toolkit 2.9.0
+Google Web Toolkit 2.10.0
 Compiler [-logLevel (ERROR|WARN|INFO|TRACE|DEBUG|SPAM|ALL)] [-workDir dir] [-X[no]closureFormattedOutput] [-[no]compileReport] [-X[no]checkCasts] [-X[no]classMetadata] [-[no]draftCompile] [-[no]checkAssertions] [-XfragmentCount numFragments] [-XfragmentMerge numFragments] [-gen dir] [-[no]generateJsInteropExports] [-includeJsInteropExports/excludeJsInteropExports regex] [-XmethodNameDisplayMode (NONE|ONLY_METHOD_NAME|ABBREVIATED|FULL)] [-Xnamespace (NONE|PACKAGE)] [-optimize level] [-[no]saveSource] [-setProperty name=value,value...] [-style (DETAILED|OBFUSCATED|PRETTY)] [-[no]failOnError] [-[no]validateOnly] [-sourceLevel [auto, 1.8, 1.9, 1.10, 1.11]] [-localWorkers count] [-[no]incremental] [-war dir] [-deploy dir] [-extra dir] [-saveSourceOutput dir] module[s]
 
 where

--- a/src/main/markdown/download.md
+++ b/src/main/markdown/download.md
@@ -42,7 +42,7 @@ Download
     <b style="color: #444;">Note</b> - This download contains the standalone GWT SDK and tools only. If you're using Eclipse, we suggest that you download and install the GWT Eclipse Plugin instead.
   </p>
   <div class='moreinfo'>
-    <a class='download-button' href="https://storage.googleapis.com/gwt-releases/gwt-2.9.0.zip">Download GWT SDK</a> <br />
+    <a class='download-button' href="https://github.com/gwtproject/gwt/releases/download/2.10.0/gwt-2.10.0.zip">Download GWT SDK</a> <br />
     <p style='font-size: 85%;'>
       <a href="versions.html">[Old versions]</a>
     </p>

--- a/src/main/markdown/gettingstarted.md
+++ b/src/main/markdown/gettingstarted.md
@@ -44,10 +44,10 @@ $JDK_HOME environment variable with export JDK_HOME="/Library/Java/Home"
   </tr>
 </tbody></table>
 
-On Windows, extract the files from the compressed folder `gwt-2.9.0.zip`.  On Mac or Linux, you can unpack the package with a command like:
+On Windows, extract the files from the compressed folder `gwt-2.10.0.zip`.  On Mac or Linux, you can unpack the package with a command like:
 
 ```
-unzip gwt-2.9.0.zip
+unzip gwt-2.10.0.zip
 ```
 
 The GWT SDK doesn't have an installer application.  All the files you  need to
@@ -62,7 +62,7 @@ You can create a new demo application in a new MyWebApp directory by running `we
 *   **Windows**
 
 ```
-cd gwt-2.9.0
+cd gwt-2.10.0
 
 webAppCreator -out MyWebApp com.mycompany.mywebapp.MyWebApp
 ```
@@ -70,7 +70,7 @@ webAppCreator -out MyWebApp com.mycompany.mywebapp.MyWebApp
 *   **Mac or Linux** - you may need to make the script executable:
 
 ```
-cd gwt-2.9.0
+cd gwt-2.10.0
 
 chmod u+x webAppCreator
 

--- a/src/main/markdown/overview.md
+++ b/src/main/markdown/overview.md
@@ -3,7 +3,7 @@ Overview
 
 GWT is a development toolkit for building and optimizing complex browser-based applications. Its goal is to enable productive development of high-performance web applications without the developer having to be an expert in browser quirks, XMLHttpRequest, and JavaScript. It's open source, completely free, and used by thousands of developers around the world.
 
-[What's New in GWT 2.9.0](release-notes.html#Release_Notes_2_9_0)
+[What's New in GWT 2.10.0](release-notes.html#Release_Notes_2_10_0)
 
 ## What's inside the toolbox?
 

--- a/src/main/markdown/release-notes.md
+++ b/src/main/markdown/release-notes.md
@@ -1,5 +1,6 @@
 The GWT Release Notes
 =====================
+* [2.10.0](#Release_Notes_2_10_0) June 9, 2022
 * [2.9.0](#Release_Notes_2_9_0) May 13, 2020
 * [2.8.2](#Release_Notes_2_8_2) Oct 19, 2017
 * [2.8.1](#Release_Notes_2_8_1) Apr 24, 2017
@@ -63,6 +64,56 @@ The GWT Release Notes
 * * *
 
 <a id="Release_Notes_Current"></a>
+<a id="Release_Notes_2_10_0"></a> Release Notes for 2.10.0
+
+### Highlights
+- Updated to HtmlUnit 2.55.0 and Jetty 9.4.44. With this newer HtmlUnit
+build comes support for Promise in unit tests, and the browser strings that
+can be specified when running tests are "FF", "Chrome", "IE" (for IE11), and
+"Safari".
+
+- Tested support for running on Java 17, dropped remaining support for
+running on Java 7.
+
+- Maven groupId is formally changed to `org.gwtproject`, projects should take
+care to ensure they are using either the old `com.google.gwt:gwt` BOM or the
+new `org.gwtproject:gwt` BOM to sure that Maven or Gradle correctly handle
+this change. This will be the last published version using the `com.google.gwt`
+groupId.
+
+- Dropped support for IE 8, 9, and 10.
+
+
+### Bug fixes
+- Correct Long.hashCode semantics
+- Support CLASSPATH environment variable when creating child processes, fixing
+  a bug where Windows could fail with a long list of arguments.
+- Use Function.name instead of displayName to support visible method names in 
+  Chrome 93+.
+- Allow stack traces to be available in Chrome when loading scripts from a remote
+  origin.
+
+### JRE Emulation
+- Added OutputStreamWriter emulation.
+- Support StringReader mark() and reset() methods.
+- Added StrictMath emulation.
+- Added BufferedWriter emulation.
+- Added incomplete PrintStream emulation.
+- Add Charset.defaultCharset() emulation.
+- Improve BigInteger emulated performance.
+- System.nanoTime() emulation with performance.now().
+- Added Optional.isEmpty emulation.
+- JRE Emulation improvements/simplifications to facilitate J2CL's WASM support.
+Note that these do not always offer specific improvements to GWT itself, but
+helps to keep the codebases consistent.
+
+### Miscellaneous
+- Add support to compile GWT itself in Java 9+.
+- Improve compiled code size for applications that never use streams, by
+  avoiding referencing streams from Throwable.
+
+For more detail, see the [commit log](https://github.com/gwtproject/gwt/compare/2.9.0...2.10.0).
+
 ## <a id="Release_Notes_2_9_0"></a> Release Notes for 2.9.0
 
 ### Highlights

--- a/src/main/markdown/versions.md
+++ b/src/main/markdown/versions.md
@@ -3,6 +3,27 @@ Versions
 
 GWT is licensed under the [Apache 2.0 open source license](terms.html) (since version 1.3).
 
+### Version 2.10.0
+
+Build 2.10.0 - June 9, 2022 - [Release notes](release-notes.html#Release_Notes_2_10_0)
+
+  <table class="downloads" style="width:500px">
+    <tbody>
+      <tr>
+        <th>Platform</th>
+        <th>Package</th>
+        <th>Size</th>
+        <th>SHA1 Sum</th>
+      </tr>
+      <tr>
+        <td>Windows, Mac OS X, and Linux</td>
+        <td>[gwt-2.10.0.zip](https://github.com/gwtproject/gwt/releases/download/2.10.0/gwt-2.10.0.zip)</td>
+        <td>88 MB</td>
+        <td>5c43e648d3b85f518bcf1703532c1e2e4292214e</td>
+      </tr>
+    </tbody>
+  </table>
+
 ### Version 2.9.0
 
 Build 2.9.0 - May 13, 2020 - [Release notes](release-notes.html#Release_Notes_2_9_0)


### PR DESCRIPTION
Changes to generated docs (javadoc, emulation summary) will follow, since that is a huge change and can't be manually reviewed like this can.