### PR TITLE
Remove Google Analytics

### DIFF
--- a/src/main/resources/main.tpl
+++ b/src/main/resources/main.tpl
@@ -15,23 +15,6 @@
         <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 
         <script type="text/javascript" src="/gwtproject/gwtproject.nocache.js"></script>
-        <script type="text/javascript">
-            var _gaq = _gaq || [];
-            _gaq.push(['_setAccount', 'UA-40673139-1']);
-            _gaq.push(['_setDomainName', 'gwtproject.org']);
-            _gaq.push(['_setAllowLinker', true]);
-            _gaq.push(['_trackPageview']);
-
-            (function () {
-                var ga = document.createElement('script');
-                ga.type = 'text/javascript';
-                ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0];
-                s.parentNode.insertBefore(ga, s);
-            })();
-
-        </script>
         <script>
             (function () {
                 var cx = '008698606704604874043:or32ypbnrfu';

--- a/src/main/site/index.html
+++ b/src/main/site/index.html
@@ -15,25 +15,6 @@
     <script>try{Typekit.load();}catch(e){}</script>
 
     <script type="text/javascript" src="/gwtproject/gwtproject.nocache.js"></script>
-    <script type="text/javascript">
-        var _gaq = _gaq || [];
-        _gaq.push(['_setAccount', 'UA-40673139-1']);
-        _gaq.push(['_setDomainName', 'gwtproject.org']);
-        _gaq.push(['_setAllowLinker', true]);
-        _gaq.push(['_trackPageview']);
-
-        (function () {
-            var ga = document.createElement('script');
-            ga.type = 'text/javascript';
-            ga.async = true;
-            ga.src =
-            ('https:' == document.location.protocol ? 'https://ssl' : 'http://www')
-            + '.google-analytics.com/ga.js';
-            var s = document.getElementsByTagName('script')[0];
-            s.parentNode.insertBefore(ga, s);
-        })();
-
-    </script>
     <script>
         (function () {
             var cx = '008698606704604874043:or32ypbnrfu';


### PR DESCRIPTION
It is unclear who has access to the account (wasn't handled over with other resources), is unnecessary, and may not be legal.

Fixes #311