### PR TITLE
Update links to source code, fix heading levels

### DIFF
--- a/src/main/java/com/google/gwt/site/markdown/MDTranslater.java
+++ b/src/main/java/com/google/gwt/site/markdown/MDTranslater.java
@@ -93,7 +93,7 @@ public class MDTranslater {
     }
 
     int index = path.indexOf(SEPARATOR + "src" + SEPARATOR);
-    return "<a class=\"icon_editGithub\" href=\"https://github.com/gwtproject/gwt-site/edit/master/"
+    return "<a class=\"icon_editGithub\" href=\"https://github.com/gwtproject/gwt-site/edit/main/"
            + path.substring(index + 1).replace(SEPARATOR, "/") + "\"></a>";
   }
 

--- a/src/main/markdown/community-group-charter.md
+++ b/src/main/markdown/community-group-charter.md
@@ -1,4 +1,4 @@
-<h2>Welcome to the GWT Discussion Group!</h2>
+# Welcome to the GWT Discussion Group!
 
 The GWT (GWT) allows developers to use the Java programming language to build no-compromise AJAX applications. This is the official discussion forum for GWT.
 

--- a/src/main/markdown/doc/latest/DevGuideClientBundle.md
+++ b/src/main/markdown/doc/latest/DevGuideClientBundle.md
@@ -571,7 +571,7 @@ background-position: left 4px top 10px;
 ImageResource logo();
 ```
 
-*   [Current auto-RTL test cases](https://gwt.googlesource.com/gwt/+/master/user/test/com/google/gwt/resources/rg)
+*   [Current auto-RTL test cases](https://github.com/gwtproject/gwt/blob/main/user/test/com/google/gwt/resources/rg)
 
 #### Selector obfuscation<a id="Selector_obfuscation"></a>
 

--- a/src/main/markdown/doc/latest/DevGuideCodingBasicsDeferred.md
+++ b/src/main/markdown/doc/latest/DevGuideCodingBasicsDeferred.md
@@ -57,9 +57,9 @@ rules are pulled into the module build through `<inherits>` elements.
 For example, the following configuration invokes deferred binding for the [PopupPanel](/javadoc/latest/com/google/gwt/user/client/ui/PopupPanel.html) widget:
 
 *   Top level `<module>.gwt.xml` _**inherits**_
-[com.google.gwt.user.User](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/User.gwt.xml)
-*   [com/google/gwt/user/User.gwt.xml](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/User.gwt.xml) _**inherits**_ [com.google.gwt.user.Popup](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/Popup.gwt.xml)
-*   [com/google/gwt/user/Popup.gwt.xml](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/Popup.gwt.xml) _**contains**_ `<replace-with>` elements to define deferred binding rules for the [PopupPanel](/javadoc/latest/com/google/gwt/user/client/ui/PopupPanel.html) class.
+[com.google.gwt.user.User](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/User.gwt.xml)
+*   [com/google/gwt/user/User.gwt.xml](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/User.gwt.xml) _**inherits**_ [com.google.gwt.user.Popup](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/Popup.gwt.xml)
+*   [com/google/gwt/user/Popup.gwt.xml](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/Popup.gwt.xml) _**contains**_ `<replace-with>` elements to define deferred binding rules for the [PopupPanel](/javadoc/latest/com/google/gwt/user/client/ui/PopupPanel.html) class.
 
 Inside the [PopupPanel](/javadoc/latest/com/google/gwt/user/client/ui/PopupPanel.html) module XML file, there
 happens to be some rules defined for deferred binding. In this case, we're using a replacement rule.
@@ -151,9 +151,9 @@ client will download based on its browser environment.
 The following is an example of how a deferred binding generator is specified to the compiler in the [module XML file](DevGuideOrganizingProjects.html#DevGuideModuleXml)
 hierarchy for the `RemoteService` class - used for GWT-RPC:
 
-*   Top level `<module>.gwt.xml` _**inherits**_ [com.google.gwt.user.User](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/User.gwt.xml)
-*   [com/google/gwt/user/User.gwt.xml](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/User.gwt.xml) _**inherits**_ [com.googl.gwt.user.RemoteService](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/RemoteService.gwt.xml)
-*   [com/google/gwt/user/RemoteService.gwt.xml](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/RemoteService.gwt.xml) _**contains**_ `<generates-with>` elements to define deferred binding rules for the `RemoteService` class.
+*   Top level `<module>.gwt.xml` _**inherits**_ [com.google.gwt.user.User](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/User.gwt.xml)
+*   [com/google/gwt/user/User.gwt.xml](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/User.gwt.xml) _**inherits**_ [com.googl.gwt.user.RemoteService](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/RemoteService.gwt.xml)
+*   [com/google/gwt/user/RemoteService.gwt.xml](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/RemoteService.gwt.xml) _**contains**_ `<generates-with>` elements to define deferred binding rules for the `RemoteService` class.
 
 ## Generator Configuration in Module XML<a id="generator"></a>
 

--- a/src/main/markdown/doc/latest/DevGuideI18nLocale.md
+++ b/src/main/markdown/doc/latest/DevGuideI18nLocale.md
@@ -159,8 +159,8 @@ or specifying `locale=` as a query string. In this case, you could write your ow
 
 A property provider is specified in the [module XML file](DevGuideOrganizingProjects.html#DevGuideModuleXml) as a JavaScript fragment that will return the value for the
 named property at runtime. In this case, you would want to define the locale property using a property provider. To see examples of `<property-provider>` definitions
-in action, see the files [I18N.gwt.xml](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/i18n/I18N.gwt.xml) and
-[UserAgent.gwt.xml](https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/UserAgent.gwt.xml) in the GWT source code.
+in action, see the files [I18N.gwt.xml](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/i18n/I18N.gwt.xml) and
+[UserAgent.gwt.xml](https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/UserAgent.gwt.xml) in the GWT source code.
 
 ## Programmatic Access to Locale Information<a id="LocaleInfo"></a>
 

--- a/src/main/markdown/doc/latest/DevGuideI18nPluralForms.md
+++ b/src/main/markdown/doc/latest/DevGuideI18nPluralForms.md
@@ -121,7 +121,7 @@ value in a properties file.
 
 See the next item for another use of Exact Values.
 
-## Offsets<a id="Offsets"><a>
+## Offsets<a id="Offsets"></a>
 
 In some cases, you may want to alter the count before applying the plural
 rules to it.  For example, if you are saying `"Bob, Joe, and 3 others ate

--- a/src/main/markdown/doc/latest/DevGuideLinkers.md
+++ b/src/main/markdown/doc/latest/DevGuideLinkers.md
@@ -1,4 +1,4 @@
-## Linkers<a id="DevGuideLinkers-intro"></a>
+# Linkers<a id="DevGuideLinkers-intro"></a>
 
 The Linker subsystem takes care of writing the GWT compiler's output. It's responsible for each output file's name, location, and content.
 

--- a/src/main/markdown/doc/latest/DevGuideLogging.md
+++ b/src/main/markdown/doc/latest/DevGuideLogging.md
@@ -43,8 +43,8 @@ You build and run LogExample the same way you would build and run any of the oth
 
 [![Logging Example web page](images/LoggingExample.png)](images/LoggingExample.png)
 
-LogExample is configured using [`LogExample.gwt.xml`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml).
-The entry point for the app is [`LogExample.java`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) &mdash; it simply creates and adds the various demo modules to the page.  Each of these modules illustrates a different set of logging concepts; this tutorial will walk you through them.
+LogExample is configured using [`LogExample.gwt.xml`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml).
+The entry point for the app is [`LogExample.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) &mdash; it simply creates and adds the various demo modules to the page.  Each of these modules illustrates a different set of logging concepts; this tutorial will walk you through them.
 
 ## Loggers, Handlers and the Root Logger<a id="Loggers_Handlers_and_the_Root_Logger"></a>
 
@@ -52,21 +52,21 @@ Loggers are organized in a tree structure, with the Root Logger at the root of t
 
 When you log a message to a logger, if the Level of the message is high enough, it will pass the message on to its parent, which will pass it on to its parent, and so on, until the Root Logger is reached.  Along the way, any given logger (including the Root Logger) will also pass the message to any of its Handlers, and if the Level of the message is high enough, those handlers will output the message in some way (to a popup, to stderr, etc.). For a much more detailed explanation of this, see [http://java.sun.com/j2se/1.4.2/docs/guide/util/logging/overview.html](http://java.sun.com/j2se/1.4.2/docs/guide/util/logging/overview.html).
 
-If you open [`LogExample.java`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) you can see that we've created 3 loggers:
+If you open [`LogExample.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) you can see that we've created 3 loggers:
 
 ```
-// <a href="https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java">LogExample.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java">LogExample.java</a>
 
   private static Logger childLogger = Logger.getLogger("ParentLogger.Child");
   private static Logger parentLogger = Logger.getLogger("ParentLogger");
   private static Logger rootLogger = Logger.getLogger("");
 ```
 
-We've passed these 3 loggers into [`LoggerController`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/LoggerController.java), which in turn, creates an instance of
-[`OneLoggerController`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java) for each of them.  In `OneLoggerController.java` you can see example code for changing the Level of the logger, logging to the logger, and logging an exception to the logger.
+We've passed these 3 loggers into [`LoggerController`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LoggerController.java), which in turn, creates an instance of
+[`OneLoggerController`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java) for each of them.  In `OneLoggerController.java` you can see example code for changing the Level of the logger, logging to the logger, and logging an exception to the logger.
 
 ```
-// <a href="https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java">OneLoggerController</a>
+// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java">OneLoggerController</a>
 
   // Change the level of the logger
   @UiHandler("levelTextBox")
@@ -125,7 +125,7 @@ GWT logging comes with a set of Handlers already defined and (by default) attach
 Here's an example of how a checkbox adds or removes a handler:
 
 ```
-// <a href="https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/HandlerController.java">HandlerController.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/HandlerController.java">HandlerController.java</a>
 
     public void onValueChange(ValueChangeEvent<Boolean> event) {
       if (checkbox.getValue()) {
@@ -158,7 +158,7 @@ Once we have one of these widgets, we simply pass it into the constructor
 of a `HasWidgetsLogHandler` and add that Handler to a logger.
 
 ```
-// <a href="https://gwt.googlesource.com/gwt/+/master/user/src/com/google/gwt/user/client/ui/VerticalPanel.java">VerticalPanel.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/client/ui/VerticalPanel.java">VerticalPanel.java</a>
 
     VerticalPanel customLogArea;
 
@@ -175,14 +175,14 @@ Although GWT emulates java.util.logging, it is important to understand the diffe
 
 To make this clear, the client-side GWT code has a Root Logger (and logger hierarchy) that is separate from the server-side code;  all of the handlers discussed above are only applicable to client-side code.  If code shared by the client and server makes logging calls, then which Root Logger (and logger hierarchy) it logs to will depend on whether it is being executed on the client or server side.  You should not add or manipulate Handlers in shared code, since this will not work as expected.
 
-In [`ServerLoggingArea.java`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/ServerLoggingArea.java), you can experiment with these concepts.  The buttons in that section will trigger logging calls on the server, as well as logging calls in [`SharedClass.java`](https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/shared/SharedClass.java) from both the client and server side.  Note the slight differences in formatting between client-side and server-side logging, as well as the different handlers each is logged to (in the tutorial, server-side logging will simply log to stderr, while client-side logging will log to all of the Handlers discussed above).
+In [`ServerLoggingArea.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/ServerLoggingArea.java), you can experiment with these concepts.  The buttons in that section will trigger logging calls on the server, as well as logging calls in [`SharedClass.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/shared/SharedClass.java) from both the client and server side.  Note the slight differences in formatting between client-side and server-side logging, as well as the different handlers each is logged to (in the tutorial, server-side logging will simply log to stderr, while client-side logging will log to all of the Handlers discussed above).
 
 ## Remote Logging<a id="Remote_Logging"></a>
 
 In order for events that are logged by client-side code to be stored on the server side, you need to use a `RemoteLogHandler`.  This handler will send log messages to the server, where they will be logged using the server-side logging mechanism. GWT currently contains a `SimpleRemoteLogHandler` which will do this in the simplest possible way (using GWT-RPC) and no intelligent batching, exponential backoffs in case of failure, and so forth.  This logger is disabled by default, but you can enable it in the .gwt.xml file (see the section on Handlers above for more details on configuring the default Handlers).
 
 ```
-# <a href="https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml">LogExample.gwt.xml</a>
+# <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml">LogExample.gwt.xml</a>
 
   <set-property name="gwt.logging.simpleRemoteHandler" value="ENABLED" />
 ```
@@ -204,7 +204,7 @@ Code that normally compiles out will still be present in Development mode.  You 
 
 ```
 
-// <a href="https://gwt.googlesource.com/gwt/+/master/samples/logexample/src/com/google/gwt/sample/logexample/client/CustomLogArea.java">VerticalPanel.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/CustomLogArea.java">VerticalPanel.java</a>
 
     // Although this code will compile out without this check in web mode, the guard will ensure
     // that the handler does not show up in development mode.

--- a/src/main/markdown/doc/latest/DevGuideLogging.md
+++ b/src/main/markdown/doc/latest/DevGuideLogging.md
@@ -43,8 +43,8 @@ You build and run LogExample the same way you would build and run any of the oth
 
 [![Logging Example web page](images/LoggingExample.png)](images/LoggingExample.png)
 
-LogExample is configured using [`LogExample.gwt.xml`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml).
-The entry point for the app is [`LogExample.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) &mdash; it simply creates and adds the various demo modules to the page.  Each of these modules illustrates a different set of logging concepts; this tutorial will walk you through them.
+LogExample is configured using [`LogExample.gwt.xml`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml).
+The entry point for the app is [`LogExample.java`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) &mdash; it simply creates and adds the various demo modules to the page.  Each of these modules illustrates a different set of logging concepts; this tutorial will walk you through them.
 
 ## Loggers, Handlers and the Root Logger<a id="Loggers_Handlers_and_the_Root_Logger"></a>
 
@@ -52,21 +52,21 @@ Loggers are organized in a tree structure, with the Root Logger at the root of t
 
 When you log a message to a logger, if the Level of the message is high enough, it will pass the message on to its parent, which will pass it on to its parent, and so on, until the Root Logger is reached.  Along the way, any given logger (including the Root Logger) will also pass the message to any of its Handlers, and if the Level of the message is high enough, those handlers will output the message in some way (to a popup, to stderr, etc.). For a much more detailed explanation of this, see [http://java.sun.com/j2se/1.4.2/docs/guide/util/logging/overview.html](http://java.sun.com/j2se/1.4.2/docs/guide/util/logging/overview.html).
 
-If you open [`LogExample.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) you can see that we've created 3 loggers:
+If you open [`LogExample.java`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java) you can see that we've created 3 loggers:
 
 ```
-// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java">LogExample.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/LogExample.java">LogExample.java</a>
 
   private static Logger childLogger = Logger.getLogger("ParentLogger.Child");
   private static Logger parentLogger = Logger.getLogger("ParentLogger");
   private static Logger rootLogger = Logger.getLogger("");
 ```
 
-We've passed these 3 loggers into [`LoggerController`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/LoggerController.java), which in turn, creates an instance of
-[`OneLoggerController`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java) for each of them.  In `OneLoggerController.java` you can see example code for changing the Level of the logger, logging to the logger, and logging an exception to the logger.
+We've passed these 3 loggers into [`LoggerController`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/LoggerController.java), which in turn, creates an instance of
+[`OneLoggerController`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java) for each of them.  In `OneLoggerController.java` you can see example code for changing the Level of the logger, logging to the logger, and logging an exception to the logger.
 
 ```
-// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java">OneLoggerController</a>
+// <a href="https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/OneLoggerController.java">OneLoggerController</a>
 
   // Change the level of the logger
   @UiHandler("levelTextBox")
@@ -125,7 +125,7 @@ GWT logging comes with a set of Handlers already defined and (by default) attach
 Here's an example of how a checkbox adds or removes a handler:
 
 ```
-// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/HandlerController.java">HandlerController.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/HandlerController.java">HandlerController.java</a>
 
     public void onValueChange(ValueChangeEvent<Boolean> event) {
       if (checkbox.getValue()) {
@@ -158,7 +158,7 @@ Once we have one of these widgets, we simply pass it into the constructor
 of a `HasWidgetsLogHandler` and add that Handler to a logger.
 
 ```
-// <a href="https://github.com/gwtproject/gwt/blob/main/user/src/com/google/gwt/user/client/ui/VerticalPanel.java">VerticalPanel.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/user/src/com/google/gwt/user/client/ui/VerticalPanel.java">VerticalPanel.java</a>
 
     VerticalPanel customLogArea;
 
@@ -175,14 +175,14 @@ Although GWT emulates java.util.logging, it is important to understand the diffe
 
 To make this clear, the client-side GWT code has a Root Logger (and logger hierarchy) that is separate from the server-side code;  all of the handlers discussed above are only applicable to client-side code.  If code shared by the client and server makes logging calls, then which Root Logger (and logger hierarchy) it logs to will depend on whether it is being executed on the client or server side.  You should not add or manipulate Handlers in shared code, since this will not work as expected.
 
-In [`ServerLoggingArea.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/ServerLoggingArea.java), you can experiment with these concepts.  The buttons in that section will trigger logging calls on the server, as well as logging calls in [`SharedClass.java`](https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/shared/SharedClass.java) from both the client and server side.  Note the slight differences in formatting between client-side and server-side logging, as well as the different handlers each is logged to (in the tutorial, server-side logging will simply log to stderr, while client-side logging will log to all of the Handlers discussed above).
+In [`ServerLoggingArea.java`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/ServerLoggingArea.java), you can experiment with these concepts.  The buttons in that section will trigger logging calls on the server, as well as logging calls in [`SharedClass.java`](https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/shared/SharedClass.java) from both the client and server side.  Note the slight differences in formatting between client-side and server-side logging, as well as the different handlers each is logged to (in the tutorial, server-side logging will simply log to stderr, while client-side logging will log to all of the Handlers discussed above).
 
 ## Remote Logging<a id="Remote_Logging"></a>
 
 In order for events that are logged by client-side code to be stored on the server side, you need to use a `RemoteLogHandler`.  This handler will send log messages to the server, where they will be logged using the server-side logging mechanism. GWT currently contains a `SimpleRemoteLogHandler` which will do this in the simplest possible way (using GWT-RPC) and no intelligent batching, exponential backoffs in case of failure, and so forth.  This logger is disabled by default, but you can enable it in the .gwt.xml file (see the section on Handlers above for more details on configuring the default Handlers).
 
 ```
-# <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml">LogExample.gwt.xml</a>
+# <a href="https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/LogExample.gwt.xml">LogExample.gwt.xml</a>
 
   <set-property name="gwt.logging.simpleRemoteHandler" value="ENABLED" />
 ```
@@ -204,7 +204,7 @@ Code that normally compiles out will still be present in Development mode.  You 
 
 ```
 
-// <a href="https://github.com/gwtproject/gwt/blob/main/samples/logexample/src/com/google/gwt/sample/logexample/client/CustomLogArea.java">VerticalPanel.java</a>
+// <a href="https://github.com/gwtproject/gwt/blob/3c49dc1b8ac1116d3436e87637c1daeb107d7ea3/samples/logexample/src/com/google/gwt/sample/logexample/client/CustomLogArea.java">VerticalPanel.java</a>
 
     // Although this code will compile out without this check in web mode, the guard will ensure
     // that the handler does not show up in development mode.

--- a/src/main/markdown/doc/latest/DevGuideMvpActivitiesAndPlaces.md
+++ b/src/main/markdown/doc/latest/DevGuideMvpActivitiesAndPlaces.md
@@ -220,7 +220,7 @@ Specify the implementation class in .gwt.xml:
 
 You can use `<when-property-is>` to specify different
 implementations based on user.agent, locale, or other properties you
-define. The [mobilewebapp](https://gwt.googlesource.com/gwt/+/master/samples/mobilewebapp/)
+define. The [mobilewebapp](https://github.com/gwtproject/gwt/blob/main/samples/mobilewebapp/)
 sample application defines a "formfactor" property used to 
 select a different view implementations for mobile, tablet, and desktop devices.
 

--- a/src/main/markdown/doc/latest/DevGuideRequestFactory.md
+++ b/src/main/markdown/doc/latest/DevGuideRequestFactory.md
@@ -60,50 +60,63 @@ entity can be persisted to a data store such as a relational database or the
 Google App Engine Datastore. In persistence frameworks like JDO and JPA,
 entities are annotated with @Entity. RequestFactory does not require the use of
 any particular framework or annotations on your domain classes.  Here's part of
-an entity definition from the [Expenses
-sample application](https://github.com/gwtproject/gwt/blob/main/samples/expenses) found in the GWT distribution.
+an entity definition from the [Mobile
+web application](https://github.com/gwtproject/gwt/blob/main/samples/mobilewebapp) found in the GWT distribution.
 
 ```
-package com.google.gwt.sample.expenses.server.domain;
+package com.google.gwt.sample.mobilewebapp.server.domain;
 
 /**
- * The Employee domain object.
+ * A task used in the task list. 
  */
 @Entity
-public class Employee {
-
-  @Size(min = 3, max = 30)
-  private String userName;
-
-  private String department;
-
-  @NotNull
-  private String displayName;
-
-  private String password;
-
-  @JoinColumn
-  private Long supervisorKey;
+public class Task {
 
   @Id
-  @Column(name = "id")
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  Long id;
 
-  @Version
-  @Column(name = "version")
-  private Integer version;
+  private Date dueDate;
 
-  @Transient
-  private Employee supervisor;
+  @NotNull(message = "You must specify a name")
+  @Size(min = 3, message = "Name must be at least 3 characters long")
+  private String name;
 
-  public String getDepartment() {
-    return department;
+  private String notes;
+
+  /**
+   * The unique ID of the user who owns this task.
+   */
+  @Index
+  private String userId;
+
+  /**
+   * Get the due date of the Task.
+   */
+  public Date getDueDate() {
+    return dueDate;
   }
 
-  public String getDisplayName() {
-    return this.displayName;
+  /**
+   * Get the unique ID of the Task.
+   */
+  public Long getId() {
+    return id;
   }
+
+  /**
+   * Get the name of the Task.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Get the notes associated with the task.
+   */
+  public String getNotes() {
+    return notes;
+  }
+
   ...
 }
 ```
@@ -684,7 +697,7 @@ any method invocation will result in changes being sent to the server.
 
 Changes to related entities can be persisted in a single request.
 For example, this code from the 
-[DynatableRF sample app](https://github.com/gwtproject/gwt/blob/main/samples/dynatablerf) in GWT trunk creates a new Person and Address at the same time:
+[DynatableRF sample app](https://github.com/gwtproject/gwt/tree/main/samples/dynatablerf) in GWT trunk creates a new Person and Address at the same time:
 
 ```
 PersonRequest context = requestFactory.personRequest();

--- a/src/main/markdown/doc/latest/DevGuideRequestFactory.md
+++ b/src/main/markdown/doc/latest/DevGuideRequestFactory.md
@@ -61,7 +61,7 @@ Google App Engine Datastore. In persistence frameworks like JDO and JPA,
 entities are annotated with @Entity. RequestFactory does not require the use of
 any particular framework or annotations on your domain classes.  Here's part of
 an entity definition from the [Expenses
-sample application](https://gwt.googlesource.com/gwt/+/master/samples/expenses) found in the GWT distribution.
+sample application](https://github.com/gwtproject/gwt/blob/main/samples/expenses) found in the GWT distribution.
 
 ```
 package com.google.gwt.sample.expenses.server.domain;
@@ -684,7 +684,7 @@ any method invocation will result in changes being sent to the server.
 
 Changes to related entities can be persisted in a single request.
 For example, this code from the 
-[DynatableRF sample app](https://gwt.googlesource.com/gwt/+/master/samples/dynatablerf) in GWT trunk creates a new Person and Address at the same time:
+[DynatableRF sample app](https://github.com/gwtproject/gwt/blob/main/samples/dynatablerf) in GWT trunk creates a new Person and Address at the same time:
 
 ```
 PersonRequest context = requestFactory.personRequest();

--- a/src/main/markdown/doc/latest/DevGuideUiBinder.md
+++ b/src/main/markdown/doc/latest/DevGuideUiBinder.md
@@ -1,3 +1,5 @@
+# UIBinder
+
 This document explains how to build Widget and DOM structures from XML markup using UiBinder, introduced with GWT 2.0. It does not cover binder's localization features&mdash;read about them in <a href="DevGuideUiBinderI18n.html">Internationalization - UiBinder</a>.
 
 1.  [Overview](#Overview)

--- a/src/main/markdown/doc/latest/DevGuideUiCellWidgets.md
+++ b/src/main/markdown/doc/latest/DevGuideUiCellWidgets.md
@@ -51,7 +51,7 @@ This document describes or points to three kinds of code examples, so you can ju
 [CellBrowser](https://samples.gwtproject.org/samples/Showcase/Showcase.html#!CwCellBrowser), plus examples of Cells in the[Cell Sampler](http://samples.gwtproject.org/samples/Showcase/Showcase.html#!CwCellSampler).
 Note: The prefix "Cw" in showcase class names stands for "ContentWidget", the parent class of each Showcase example.
 *   **Simplified examples** - The code examples displayed in-line throughout this documented are short, simplified examples, often pared-down versions of the real-world examples.
-*   **Real-world examples** - Most of the cell widgets also have source code examples (.java files) at    [cell widget code examples](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview).
+*   **Real-world examples** - Most of the cell widgets also have source code examples (.java files) at    [cell widget code examples](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview).
 
 These files are referenced, where appropriate, in the sections below.
 
@@ -75,7 +75,7 @@ renders the data for a selected contact.
 
 The data inserted in the last step is updated by the data provider ([ListDataProvider](/javadoc/latest/com/google/gwt/view/client/ListDataProvider.html) or [AsyncDataProvider](/javadoc/latest/com/google/gwt/view/client/AsyncDataProvider.html)).  If you need to allow the user to modify the content of a cell and update the database, use ValueUpdater instead of setRowData in the last step, as described in [Updating a Database From a CellList](#updating-from-celllist).
 
-**Code Example** - The example below is available at [CellListExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellListExample.java)
+**Code Example** - The example below is available at [CellListExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellListExample.java)
 
 The following code is a very simple example that creates a CellList widget containing a single TextCell and sets data from the data source.  The list shows names.
 
@@ -135,7 +135,7 @@ The data inserted in the last step is updated by the data provider ([ListDataPro
 **More Information** - Read the [Cell Table Developer Guide](DevGuideUiCellTable.html) for more
 information about CellTable-specific features, such as column sorting.
 
-**Code Example** - The example below is a pared-down version of [CellTableExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellTableExample.java)
+**Code Example** - The example below is a pared-down version of [CellTableExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellTableExample.java)
 
 ```
 /**
@@ -220,9 +220,9 @@ A CellTree can have its own CSS styles and its own resources, such as images tha
 2.  Create an instance of your TreeViewModel class.
 3.  Create a [CellTree](/javadoc/latest/com/google/gwt/user/cellview/client/CellTree.html), passing in the TreeViewModel instance.
 
-**Code Example #1** - The example below is a simplified example of CellTree, and is available at  [CellTreeExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellTreeExample.java).
+**Code Example #1** - The example below is a simplified example of CellTree, and is available at  [CellTreeExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellTreeExample.java).
 
-**Code Example #2** - For a real-world example of CellTree, see [CellTreeExample2.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellTreeExample2.java).
+**Code Example #2** - For a real-world example of CellTree, see [CellTreeExample2.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellTreeExample2.java).
 
 ```
 /**
@@ -286,9 +286,9 @@ CellBrowser is similar to a CellTree but displays the node levels side-by-side. 
     CellBrowser browser = new CellBrowser(model, "Item 1");
 ```
 
-**Code Example #1** - For a simple example of CellBrowser, see [CellBrowerExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellBrowserExample.java). 
+**Code Example #1** - For a simple example of CellBrowser, see [CellBrowerExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellBrowserExample.java). 
 
-**Code Example #2** - For a real-world example of CellBrowser, see [CellBrowserExample2.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellBrowserExample2.java).
+**Code Example #2** - For a real-world example of CellBrowser, see [CellBrowserExample2.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellBrowserExample2.java).
 
 ## Cells<a id="Cells"></a>
 
@@ -354,7 +354,7 @@ By using a subscription model, we can link selection across multiple views. If m
 4.  Create a [SelectionChangeEvent.Handler](/javadoc/latest/com/google/gwt/view/client/SelectionChangeEvent.Handler.html) implementing onSelectionChange.
 5.  Add this handler to the SelectionModel using [addSelectionChangeHandler](/javadoc/latest/com/google/gwt/view/client/SelectionModel.html#addSelectionChangeHandler-com.google.gwt.view.client.SelectionChangeEvent.Handler-).
 
-**Code Example** - The example of SelectionModel below is available at [CellListExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellListExample.java).
+**Code Example** - The example of SelectionModel below is available at [CellListExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellListExample.java).
 
 ```
 /**
@@ -405,7 +405,7 @@ Every DTO (Data Transfer Object) must have a key associated with it in order to 
 
 Keys allow us to associate ViewData, such as selection state and validation information, with a DTO.  If you select some items in a table or list, then when the list refreshes with new data, you can maintain the same selection.
 
-**Code Example** - The example of KeyProvider below is available at [KeyProviderExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/view/KeyProviderExample.java).
+**Code Example** - The example of KeyProvider below is available at [KeyProviderExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/view/KeyProviderExample.java).
 
 ```
 /**
@@ -689,7 +689,7 @@ Two procedures follow &mdash; one for adding a standard SimplePager to a cell wi
 
 **Demo** - [CwCellTable example](https://samples.gwtproject.org/samples/Showcase/Showcase.html#!CwCellTable) shows a SimplePager control below a table.
 
-**Code Example** - The example below is available at  [SimplePagerExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/SimplePagerExample.java).
+**Code Example** - The example below is available at  [SimplePagerExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/SimplePagerExample.java).
 
 **To Add SimplePager to a Cell Widget:**
 
@@ -755,7 +755,7 @@ When the user makes the change to the data, the Cell receives an event in its [o
 
 **Demo** - _(none)_
 
-**Code Example** - The example below is available at [CellListValueUpdaterExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellListValueUpdaterExample.java).
+**Code Example** - The example below is available at [CellListValueUpdaterExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellListValueUpdaterExample.java).
 
 **To Update the Database from a CellList:**
 
@@ -818,7 +818,7 @@ Use a [FieldUpdater](/javadoc/latest/com/google/gwt/cell/client/FieldUpdater.htm
 1.  Create a class that implements [FieldUpdater](/javadoc/latest/com/google/gwt/cell/client/FieldUpdater.html) to accept a new data value and send it to your database.
 2.  Set the FieldUpdater in the Column by calling  [column.setFieldUpdater(fieldUpdater)](/javadoc/latest/com/google/gwt/user/cellview/client/Column.html#setFieldUpdater-com.google.gwt.cell.client.FieldUpdater-).
 
-**Code Example** - An example is available at [CellTableFieldUpdaterExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cellview/CellTableFieldUpdaterExample.java).
+**Code Example** - An example is available at [CellTableFieldUpdaterExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cellview/CellTableFieldUpdaterExample.java).
 
 ```
 /**

--- a/src/main/markdown/doc/latest/DevGuideUiCss.md
+++ b/src/main/markdown/doc/latest/DevGuideUiCss.md
@@ -1,3 +1,5 @@
+# CSS Styling
+
 Like most web applications, GWT applications use cascading style sheets (CSS) for visual styling.
 
 *   [Styling Existing Widgets](#widgets)

--- a/src/main/markdown/doc/latest/DevGuideUiCustomCells.md
+++ b/src/main/markdown/doc/latest/DevGuideUiCustomCells.md
@@ -57,7 +57,7 @@ When implementing a render method, you should follow these steps:
     tries to enforce this.
 4.  Render the HTML that represents the Cell into the SafeHtmlBuilder.
 
-You can download this example at [CellExample.java](https://gwt.googlesource.com/gwt/+/master/user/javadoc/com/google/gwt/examples/cell/CellExample.java).
+You can download this example at [CellExample.java](https://github.com/gwtproject/gwt/blob/main/user/javadoc/com/google/gwt/examples/cell/CellExample.java).
 
 ```
 /**

--- a/src/main/markdown/doc/latest/DevGuideUiEditors.md
+++ b/src/main/markdown/doc/latest/DevGuideUiEditors.md
@@ -204,7 +204,7 @@ The GWT distribution provides the following Editor adapter classes that provide 
 *   `ListEditor` keeps a `List<T>` in sync with a list of sub-Editors.
     *   The `ListEditor` is created with a user-provided `EditorSource` which vends sub-Editors (usually Widget subtypes).
     *   Changes made to the structure of the `List` returned by `ListEditor.getList()` will be reflected in calls made to the `EditorSource`.
-    *   [Sample code](https://github.com/gwtproject/gwt/blob/main/samples/dynatablerf/#dynatablerf/src/main/java/com/google/gwt/sample/dynatablerf/client/widgets/FavoritesWidget.java).
+    *   [Sample code](https://github.com/gwtproject/gwt/blob/main/samples/dynatablerf/src/main/java/com/google/gwt/sample/dynatablerf/client/widgets/FavoritesWidget.java).
 *   `OptionalFieldEditor` can be used with nullable or resettable bean properties.
 *   `SimpleEditor` can be used as a headless property Editor
 *   `TakesValueEditor` adapts a `TakesValue<T>` to a `LeafValueEditor<T>`

--- a/src/main/markdown/doc/latest/DevGuideUiEditors.md
+++ b/src/main/markdown/doc/latest/DevGuideUiEditors.md
@@ -204,7 +204,7 @@ The GWT distribution provides the following Editor adapter classes that provide 
 *   `ListEditor` keeps a `List<T>` in sync with a list of sub-Editors.
     *   The `ListEditor` is created with a user-provided `EditorSource` which vends sub-Editors (usually Widget subtypes).
     *   Changes made to the structure of the `List` returned by `ListEditor.getList()` will be reflected in calls made to the `EditorSource`.
-    *   [Sample code](https://gwt.googlesource.com/gwt/+/master/samples/dynatablerf/#dynatablerf/src/main/java/com/google/gwt/sample/dynatablerf/client/widgets/FavoritesWidget.java).
+    *   [Sample code](https://github.com/gwtproject/gwt/blob/main/samples/dynatablerf/#dynatablerf/src/main/java/com/google/gwt/sample/dynatablerf/client/widgets/FavoritesWidget.java).
 *   `OptionalFieldEditor` can be used with nullable or resettable bean properties.
 *   `SimpleEditor` can be used as a headless property Editor
 *   `TakesValueEditor` adapts a `TakesValue<T>` to a `LeafValueEditor<T>`

--- a/src/main/markdown/doc/latest/polymer-tutorial/create.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/create.md
@@ -1,4 +1,4 @@
-# Creating the *TodoList* Project
+# Creating the *TodoList* Project
 
 In this section, we'll create the **TodoList** project from scratch using GWT's [webAppCreator](https://www.gwtproject.org/doc/latest/RefCommandLineTools.html#webAppCreator), a command-line utility.
 

--- a/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/elements-buildui.md
@@ -1,4 +1,4 @@
-# Building the UI
+# Building the UI
 
 In this chapter we'll build a modern looking UI for the **TodoList** application using the [Material Design](https://material.google.com) specifications. We'll be working with the Vaadin gwt-polymer-elements library, a wrapper for the Polymer Paper Elements collection.
 
@@ -307,7 +307,7 @@ In this chapter we'll build a modern looking UI for the **TodoList** application
 
     <img class='polymer-tutorial-screenshot' src='images/todo-list-05.png'>
 
-## Styling the App
+## Styling the App
 
 Web Components use [Shadow DOM styling](http://www.html5rocks.com/en/tutorials/webcomponents/shadowdom-201/) rules for providing scoped styling of the element. Additionally Polymer provides [Shady DOM](https://www.polymer-project.org/1.0/articles/shadydom.html) to deal with browsers not implementing native shadow. Hence Polymer monitors and parses each `<style>` block rewriting rules on the fly.
 

--- a/src/main/markdown/doc/latest/polymer-tutorial/widgets-buildui.md
+++ b/src/main/markdown/doc/latest/polymer-tutorial/widgets-buildui.md
@@ -1,4 +1,4 @@
-# Building the UI with GWT Widgets.
+# Building the UI with GWT Widgets.
 
 
 In this chapter we'll build a modern looking UI for the **TodoList** application using the [Material Design](https://material.google.com) specifications. We'll be working with the Vaadin gwt-polymer-elements library, a wrapper for the Polymer Paper Elements collection.
@@ -264,7 +264,7 @@ In this chapter we'll build a modern looking UI for the **TodoList** application
 
     <img class='polymer-tutorial-screenshot' src='images/todo-list-05.png'>
 
-## Styling the App
+## Styling the App
 
 ### Styling with `CssResource`
 When using Polymer widgets you can use GWT [GSS](https://www.gwtproject.org/doc/latest/DevGuideGssVsCss.html) parser as usual, and add styles to widgets or elements using the `{}` operator.

--- a/src/main/markdown/lifeofanissue.md
+++ b/src/main/markdown/lifeofanissue.md
@@ -24,7 +24,7 @@ Here's the Life of an Issue, in a nutshell:
 1.  An issue is filed.
 2.  A GWT contributor periodically reviews and triages issues. The GWT contributor attempts to verify the issue and assigns a status based on the results.
 3.  Once an issue has been verified, it may be marked Accepted, in which case the GWT team plans to fix it, or PatchesWelcome, which means that the GWT team likely won't be able to get to it, but would be happy to review patches from the community. To submit a patch, follow [these guidelines](makinggwtbetter.html#submittingpatches).
-4.  Once an issue has been fixed, it'll be closed and assigned to a milestone, indicating whether the fix is available in the current numbered release or, more commonly, in the Git master branch for the next release.
+4.  Once an issue has been fixed, it'll be closed and assigned to a milestone, indicating whether the fix is available in the current numbered release or, more commonly, in the Git main branch for the next release.
 
 The following tables provide detail on all issue status types.
 

--- a/src/main/markdown/makinggwtbetter.md
+++ b/src/main/markdown/makinggwtbetter.md
@@ -249,7 +249,7 @@ the GWT build; style issues that can't be caught by the build system should be
 addressed during code review.
 
 To make it easier to format your GWT code correctly, use the
-[GWT style formatter](https://gwt.googlesource.com/gwt/+/master/eclipse/settings/code-style/gwt-format.xml)
+[GWT style formatter](https://github.com/gwtproject/gwt/blob/main/eclipse/settings/code-style/gwt-format.xml)
 for Eclipse (Preferences | Java > Code Style > Formatter | Import...).
 
 In general, the GWT style is based on [the
@@ -579,4 +579,4 @@ Since our .gitignore files don't contain IDE or OS specific .gitignore entries y
 
 [This](https://help.github.com/articles/ignoring-files) is how you setup a global .gitignore.
 
-[Here](https://github.com/github/gitignore/tree/master/Global) you find a list of IDE specific global .gitignore files.
+[Here](https://github.com/github/gitignore/tree/main/Global) you find a list of IDE specific global .gitignore files.

--- a/src/main/markdown/meetingnotes/2015-02-11.md
+++ b/src/main/markdown/meetingnotes/2015-02-11.md
@@ -1,4 +1,4 @@
-## 11 February 2015
+# 11 February 2015
 
 * GWT 2.8 release
     * Manuel and Julien will do the release. Julien will be the point person.

--- a/src/main/markdown/meetingnotes/2015-06-17.md
+++ b/src/main/markdown/meetingnotes/2015-06-17.md
@@ -1,4 +1,4 @@
-## 17 June 2015
+# 17 June 2015
 
 Agenda:
 

--- a/src/main/markdown/meetingnotes/2015-08-19.md
+++ b/src/main/markdown/meetingnotes/2015-08-19.md
@@ -1,4 +1,4 @@
-## 19 Aug 2015
+# 19 Aug 2015
 
 * Dev mode discussion
     * Daniel is migrating test cases to compile-mode, no more need to support dev-mode within Google.

--- a/src/main/markdown/meetingnotes/2015-10-28.md
+++ b/src/main/markdown/meetingnotes/2015-10-28.md
@@ -1,4 +1,4 @@
-## 28 October 2015
+# 28 October 2015
 
 * GWT 2.8
     * Plan to create an RC1 on Monday, Nov 2.

--- a/src/main/markdown/meetingnotes/2016-01-10.md
+++ b/src/main/markdown/meetingnotes/2016-01-10.md
@@ -1,4 +1,4 @@
-## 10 January 2016
+# 10 January 2016
 
 
 * No quorum, we only have 4 people show up. May want to plan a follow-up meeting. Bhaskar will ask SC members if they want one.

--- a/src/main/markdown/meetingnotes/2016-02-10.md
+++ b/src/main/markdown/meetingnotes/2016-02-10.md
@@ -1,4 +1,4 @@
-## 10 February 2016
+# 10 February 2016
 
 GWT 2.8 Status:
 

--- a/src/main/markdown/meetingnotes/2016-04-13.md
+++ b/src/main/markdown/meetingnotes/2016-04-13.md
@@ -1,4 +1,4 @@
-## 13 April 2016
+# 13 April 2016
  
 * Java8
     * Good progress in adding support. 

--- a/src/main/markdown/meetingnotes/2016-07-20.md
+++ b/src/main/markdown/meetingnotes/2016-07-20.md
@@ -1,4 +1,4 @@
-## 20 July 2016
+# 20 July 2016
 
 * GWT 2.8
     * Daniel did some pre-testing & smoke tests. 

--- a/src/main/markdown/meetingnotes/2017-01-11.md
+++ b/src/main/markdown/meetingnotes/2017-01-11.md
@@ -1,4 +1,4 @@
-## 11 January 2017
+# 11 January 2017
 
 Present: Christian, Daniel, Leif, Stephen, Thomas, Colin
 

--- a/src/main/markdown/meetingnotes/2017-02-08.md
+++ b/src/main/markdown/meetingnotes/2017-02-08.md
@@ -1,4 +1,4 @@
-## 8 February 2017
+# 8 February 2017
 
 Present: Leif, Justin, Bhaskar, Daniel, Thomas, Colin
 

--- a/src/main/markdown/meetingnotes/2017-03-08.md
+++ b/src/main/markdown/meetingnotes/2017-03-08.md
@@ -1,3 +1,3 @@
-## 08 March 2017
+# 08 March 2017
 
 Not enough members present.

--- a/src/main/markdown/meetingnotes/2017-04-12.md
+++ b/src/main/markdown/meetingnotes/2017-04-12.md
@@ -1,4 +1,4 @@
-## 12 April 2017
+# 12 April 2017
 
 Present: Leif, Colin, Maxime, Thomas, Bhaskar
 

--- a/src/main/markdown/meetingnotes/2017-05-10.md
+++ b/src/main/markdown/meetingnotes/2017-05-10.md
@@ -1,4 +1,4 @@
-## 10 May 2017
+# 10 May 2017
 
 Present: Christian, Goktug, Julien, Justin, Leif, Thomas, Colin, Bhaskar
 


### PR DESCRIPTION
The "edit on GitHub" link is not positioned correctly on pages that use `<h2>` instead of `<h1>` and it points to a wrong branch.

While fixing that, I also updated some links that point to googlesource and should point to GH.