### PR TITLE
Switch to show new gettingstarted-v2.md by default.

### DIFF
--- a/src/main/site/index.html
+++ b/src/main/site/index.html
@@ -41,7 +41,7 @@
                 <ul>
                     <li class="logo"><a href="/">GWT homepage</a></li>
                     <li><a href="overview.html"><i class="icon_overview"></i>Overview</a></li>
-                    <li class="sep"><a href="gettingstarted.html"><i class="icon_getstarted"></i>Get started</a></li>
+                    <li class="sep"><a href="gettingstarted-v2.html"><i class="icon_getstarted"></i>Get started</a></li>
                     <li><a href="doc/latest/tutorial/index.html" class="active"><i class="icon_tutorials"></i>Tutorials</a></li>
                     <li><a href="doc/latest/DevGuide.html"><i class="icon_doc"></i>Docs</a></li>
                     <li><a href="examples.html"><i class="icon_ressources"></i>Resources</a></li>
@@ -171,7 +171,7 @@
                         <div class="clearfix nodesktop"></div>
 
                         <div class="col col-1_4 col-t1_2 col-mfull">
-                            <a href="gettingstarted.html">
+                            <a href="gettingstarted-v2.html">
                                 <i class="icon_getstarted"></i>
                                 <h2>Get started</h2>
 


### PR DESCRIPTION
Switch to show new gettingstarted-v2.md in the main menu.  Ie: Here:

![image](https://github.com/user-attachments/assets/75154e4e-e164-4e4a-89d2-1f90541dd33c)


_Note:_  To test this change, I had to add:
```
set JDK_JAVA_OPTIONS=--add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED
```
before running `mvn clean install`, otherwise I gor the error:
```
java.lang.RuntimeException: Error creating extended parser class: Could not determine whether class 'org.pegdown.Parser$$parboiled' has already been loaded
```
Probably because I'm running Java 17.
